### PR TITLE
test: add adapter and config model tests

### DIFF
--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,338 @@
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from metareason.adapters.adapter_base import (
+    AdapterException,
+    AdapterRequest,
+    AdapterResponse,
+)
+from metareason.adapters.adapter_factory import get_adapter
+from metareason.adapters.anthropic import AnthropicAdapter, AnthropicAdapterException
+from metareason.adapters.google import GoogleAdapter, GoogleAdapterException
+from metareason.adapters.ollama import OllamaAdapter, OllamaException
+from metareason.adapters.openai import OpenAIAdapter, OpenAIAdapterException
+
+
+@pytest.fixture
+def adapter_request():
+    return AdapterRequest(
+        model="test-model",
+        system_prompt="You are helpful.",
+        user_prompt="Hello",
+        temperature=0.7,
+        top_p=0.9,
+        max_tokens=100,
+    )
+
+
+@pytest.fixture
+def adapter_request_no_system():
+    return AdapterRequest(
+        model="test-model",
+        user_prompt="Hello",
+        temperature=0.7,
+        top_p=0.9,
+        max_tokens=100,
+    )
+
+
+# --- AdapterRequest / AdapterResponse validation ---
+
+
+class TestAdapterModels:
+    def test_adapter_request_valid(self):
+        req = AdapterRequest(
+            model="m", user_prompt="hi", temperature=1.0, top_p=0.5, max_tokens=10
+        )
+        assert req.model == "m"
+        assert req.system_prompt is None
+
+    def test_adapter_request_temperature_too_high(self):
+        with pytest.raises(ValidationError):
+            AdapterRequest(
+                model="m", user_prompt="hi", temperature=3.0, top_p=0.5, max_tokens=10
+            )
+
+    def test_adapter_request_top_p_zero(self):
+        with pytest.raises(ValidationError):
+            AdapterRequest(
+                model="m", user_prompt="hi", temperature=1.0, top_p=0.0, max_tokens=10
+            )
+
+    def test_adapter_request_max_tokens_zero(self):
+        with pytest.raises(ValidationError):
+            AdapterRequest(
+                model="m", user_prompt="hi", temperature=1.0, top_p=0.5, max_tokens=0
+            )
+
+    def test_adapter_response_valid(self):
+        resp = AdapterResponse(response_text="hello")
+        assert resp.response_text == "hello"
+
+
+# --- Adapter Factory ---
+
+
+class TestAdapterFactory:
+    def test_get_adapter_ollama(self):
+        mock_cls = MagicMock()
+        with patch.dict(
+            "metareason.adapters.adapter_factory.ADAPTER_REGISTRY",
+            {"ollama": mock_cls},
+        ):
+            adapter = get_adapter("ollama")
+        mock_cls.assert_called_once()
+        assert adapter is mock_cls.return_value
+
+    def test_get_adapter_unknown_raises(self):
+        with pytest.raises(AdapterException, match="Unknown adapter"):
+            get_adapter("nonexistent")
+
+    @patch("metareason.adapters.adapter_factory.OllamaAdapter")
+    def test_factory_sanitizes_keys_in_log(self, mock_cls, caplog):
+        import logging
+
+        mock_cls.return_value = MagicMock()
+        with caplog.at_level(logging.DEBUG):
+            get_adapter("ollama", api_key="secret123", location="us")
+        assert "secret123" not in caplog.text
+
+    @patch("metareason.adapters.adapter_factory.OpenAIAdapter")
+    def test_factory_wraps_init_exception(self, mock_cls):
+        mock_cls.side_effect = TypeError("bad kwarg")
+        with pytest.raises(AdapterException, match="Failed to initialize"):
+            get_adapter("openai")
+
+
+# --- Ollama Adapter ---
+
+
+class TestOllamaAdapter:
+    @patch("metareason.adapters.ollama.AsyncClient")
+    def test_init_creates_client(self, mock_client_cls):
+        adapter = OllamaAdapter()
+        assert adapter.chat_client is not None
+
+    @patch("metareason.adapters.ollama.AsyncClient")
+    @pytest.mark.asyncio
+    async def test_send_request_success(self, mock_client_cls, adapter_request):
+        mock_chat = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.message.content = "Test response"
+        mock_chat.return_value = mock_response
+        mock_client_cls.return_value.chat = mock_chat
+
+        adapter = OllamaAdapter()
+        result = await adapter.send_request(adapter_request)
+
+        assert isinstance(result, AdapterResponse)
+        assert result.response_text == "Test response"
+        mock_chat.assert_called_once()
+
+    @patch("metareason.adapters.ollama.AsyncClient")
+    @pytest.mark.asyncio
+    async def test_send_request_without_system_prompt(
+        self, mock_client_cls, adapter_request_no_system
+    ):
+        mock_chat = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.message.content = "Response"
+        mock_chat.return_value = mock_response
+        mock_client_cls.return_value.chat = mock_chat
+
+        adapter = OllamaAdapter()
+        result = await adapter.send_request(adapter_request_no_system)
+
+        assert result.response_text == "Response"
+        call_kwargs = mock_chat.call_args
+        messages = call_kwargs.kwargs["messages"]
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+
+    @patch("metareason.adapters.ollama.AsyncClient")
+    @pytest.mark.asyncio
+    async def test_send_request_module_not_found(
+        self, mock_client_cls, adapter_request
+    ):
+        mock_client_cls.return_value.chat = AsyncMock(
+            side_effect=ModuleNotFoundError("not found")
+        )
+        adapter = OllamaAdapter()
+        with pytest.raises(OllamaException, match="not found"):
+            await adapter.send_request(adapter_request)
+
+
+# --- OpenAI Adapter ---
+
+
+class TestOpenAIAdapter:
+    @patch("metareason.adapters.openai.AsyncOpenAI")
+    def test_init_with_api_key(self, mock_openai_cls):
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            adapter = OpenAIAdapter()
+            assert adapter.client is not None
+
+    def test_init_missing_api_key_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(OpenAIAdapterException, match="OPENAI_API_KEY"):
+                OpenAIAdapter()
+
+    @patch("metareason.adapters.openai.AsyncOpenAI")
+    @pytest.mark.asyncio
+    async def test_send_request_success(self, mock_openai_cls, adapter_request):
+        mock_response = MagicMock()
+        mock_response.output_text = "OpenAI response"
+        mock_create = AsyncMock(return_value=mock_response)
+        mock_client = MagicMock()
+        mock_client.responses.create = mock_create
+        mock_openai_cls.return_value = mock_client
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            adapter = OpenAIAdapter()
+        result = await adapter.send_request(adapter_request)
+
+        assert isinstance(result, AdapterResponse)
+        assert result.response_text == "OpenAI response"
+
+    @patch("metareason.adapters.openai.AsyncOpenAI")
+    @pytest.mark.asyncio
+    async def test_send_request_includes_system_prompt(
+        self, mock_openai_cls, adapter_request
+    ):
+        mock_response = MagicMock()
+        mock_response.output_text = "response"
+        mock_create = AsyncMock(return_value=mock_response)
+        mock_client = MagicMock()
+        mock_client.responses.create = mock_create
+        mock_openai_cls.return_value = mock_client
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            adapter = OpenAIAdapter()
+        await adapter.send_request(adapter_request)
+
+        call_kwargs = mock_create.call_args.kwargs
+        messages = call_kwargs["messages"]
+        assert messages[0]["role"] == "developer"
+        assert messages[0]["content"] == "You are helpful."
+
+
+# --- Anthropic Adapter ---
+
+
+class TestAnthropicAdapter:
+    @patch("metareason.adapters.anthropic.AsyncAnthropic")
+    def test_init_with_api_key(self, mock_anthropic_cls):
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            adapter = AnthropicAdapter()
+            assert adapter.client is not None
+
+    def test_init_missing_api_key_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(AnthropicAdapterException, match="ANTHROPIC_API_KEY"):
+                AnthropicAdapter()
+
+    @patch("metareason.adapters.anthropic.AsyncAnthropic")
+    @pytest.mark.asyncio
+    async def test_send_request_success(self, mock_anthropic_cls, adapter_request):
+        mock_text_block = MagicMock()
+        mock_text_block.text = "Claude response"
+        mock_response = MagicMock()
+        mock_response.content = [mock_text_block]
+        mock_create = AsyncMock(return_value=mock_response)
+        mock_client = MagicMock()
+        mock_client.messages.create = mock_create
+        mock_anthropic_cls.return_value = mock_client
+
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            adapter = AnthropicAdapter()
+        result = await adapter.send_request(adapter_request)
+
+        assert isinstance(result, AdapterResponse)
+        assert result.response_text == "Claude response"
+
+    @patch("metareason.adapters.anthropic.AsyncAnthropic")
+    @pytest.mark.asyncio
+    async def test_send_request_passes_system_prompt(
+        self, mock_anthropic_cls, adapter_request
+    ):
+        mock_text_block = MagicMock()
+        mock_text_block.text = "response"
+        mock_response = MagicMock()
+        mock_response.content = [mock_text_block]
+        mock_create = AsyncMock(return_value=mock_response)
+        mock_client = MagicMock()
+        mock_client.messages.create = mock_create
+        mock_anthropic_cls.return_value = mock_client
+
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            adapter = AnthropicAdapter()
+        await adapter.send_request(adapter_request)
+
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs["system"] == "You are helpful."
+
+
+# --- Google Adapter ---
+
+
+class TestGoogleAdapter:
+    def test_init_stores_config(self):
+        adapter = GoogleAdapter(vertex_ai=True, project_id="proj")
+        assert adapter.vertex_ai is True
+        assert adapter.config["project_id"] == "proj"
+
+    def test_init_developer_api_missing_key_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            adapter = GoogleAdapter()
+            with pytest.raises(GoogleAdapterException, match="api_key is required"):
+                adapter._init_developer_api()
+
+    def test_init_vertex_ai_missing_project_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            adapter = GoogleAdapter(vertex_ai=True)
+            with pytest.raises(GoogleAdapterException, match="project_id is required"):
+                adapter._init_vertex_ai()
+
+    def test_init_vertex_ai_missing_location_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            adapter = GoogleAdapter(vertex_ai=True, project_id="proj")
+            with pytest.raises(GoogleAdapterException, match="location is required"):
+                adapter._init_vertex_ai()
+
+    @patch("metareason.adapters.google.Client")
+    @pytest.mark.asyncio
+    async def test_send_request_developer_api(self, mock_client_cls, adapter_request):
+        mock_response = MagicMock()
+        mock_response.text = "Google response"
+        mock_aio = AsyncMock()
+        mock_aio.models.generate_content = AsyncMock(return_value=mock_response)
+        mock_aio.aclose = AsyncMock()
+        mock_client_cls.return_value.aio = mock_aio
+
+        with patch.dict(os.environ, {"GOOGLE_API_KEY": "test-key"}):
+            adapter = GoogleAdapter()
+            result = await adapter.send_request(adapter_request)
+
+        assert isinstance(result, AdapterResponse)
+        assert result.response_text == "Google response"
+        mock_aio.aclose.assert_called_once()
+
+    @patch("metareason.adapters.google.Client")
+    @pytest.mark.asyncio
+    async def test_send_request_vertex_ai(self, mock_client_cls, adapter_request):
+        mock_response = MagicMock()
+        mock_response.text = "Vertex response"
+        mock_aio = AsyncMock()
+        mock_aio.models.generate_content = AsyncMock(return_value=mock_response)
+        mock_aio.aclose = AsyncMock()
+        mock_client_cls.return_value.aio = mock_aio
+
+        with patch.dict(os.environ, {"GOOGLE_GENAI_USE_VERTEXAI": "1"}, clear=False):
+            adapter = GoogleAdapter(vertex_ai=True)
+            result = await adapter.send_request(adapter_request)
+
+        assert result.response_text == "Vertex response"
+        mock_aio.aclose.assert_called_once()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,283 @@
+import pytest
+from pydantic import ValidationError
+
+from metareason.config.models import (
+    AdapterConfig,
+    AxisConfig,
+    BayesianAnalysisConfig,
+    OracleConfig,
+    PipelineConfig,
+    SamplingConfig,
+    SpecConfig,
+)
+
+# --- Helpers ---
+
+
+def make_pipeline(**overrides):
+    defaults = dict(
+        template="Hello {{ name }}",
+        adapter=AdapterConfig(name="ollama"),
+        model="llama2",
+        temperature=0.7,
+        top_p=0.9,
+        max_tokens=100,
+    )
+    defaults.update(overrides)
+    return PipelineConfig(**defaults)
+
+
+def make_oracle(**overrides):
+    defaults = dict(
+        type="llm_judge",
+        model="llama2",
+        adapter=AdapterConfig(name="ollama"),
+        rubric="Score 1-5",
+    )
+    defaults.update(overrides)
+    return OracleConfig(**defaults)
+
+
+def make_sampling(**overrides):
+    defaults = dict(method="latin_hypercube", optimization="maximin")
+    defaults.update(overrides)
+    return SamplingConfig(**defaults)
+
+
+# --- AdapterConfig ---
+
+
+class TestAdapterConfig:
+    def test_valid_adapters(self):
+        for name in ("ollama", "google", "openai", "anthropic"):
+            cfg = AdapterConfig(name=name)
+            assert cfg.name == name
+            assert cfg.params == {}
+
+    def test_with_params(self):
+        cfg = AdapterConfig(name="google", params={"api_key": "xxx"})
+        assert cfg.params["api_key"] == "xxx"
+
+    def test_invalid_adapter_name(self):
+        with pytest.raises(ValidationError):
+            AdapterConfig(name="invalid")
+
+
+# --- AxisConfig ---
+
+
+class TestAxisConfig:
+    def test_categorical_axis(self):
+        axis = AxisConfig(name="tone", type="categorical", values=["formal", "casual"])
+        assert axis.name == "tone"
+        assert axis.type == "categorical"
+        assert axis.values == ["formal", "casual"]
+
+    def test_continuous_axis(self):
+        axis = AxisConfig(
+            name="temp",
+            type="continuous",
+            distribution="uniform",
+            params={"min": 0.0, "max": 1.0},
+        )
+        assert axis.distribution == "uniform"
+        assert axis.params["min"] == 0.0
+
+    def test_defaults(self):
+        axis = AxisConfig(name="x", type="categorical")
+        assert axis.values == []
+        assert axis.weights == []
+        assert axis.distribution is None
+        assert axis.params == {}
+
+    def test_invalid_type(self):
+        with pytest.raises(ValidationError):
+            AxisConfig(name="x", type="discrete")
+
+    def test_invalid_distribution(self):
+        with pytest.raises(ValidationError):
+            AxisConfig(name="x", type="continuous", distribution="exponential")
+
+
+# --- PipelineConfig ---
+
+
+class TestPipelineConfig:
+    def test_valid_pipeline(self):
+        pipe = make_pipeline()
+        assert pipe.template == "Hello {{ name }}"
+        assert pipe.temperature == 0.7
+
+    def test_temperature_too_high(self):
+        with pytest.raises(ValidationError):
+            make_pipeline(temperature=5.0)
+
+    def test_temperature_negative(self):
+        with pytest.raises(ValidationError):
+            make_pipeline(temperature=-1.0)
+
+    def test_top_p_zero(self):
+        with pytest.raises(ValidationError):
+            make_pipeline(top_p=0.0)
+
+    def test_top_p_above_one(self):
+        with pytest.raises(ValidationError):
+            make_pipeline(top_p=1.5)
+
+    def test_boundary_values(self):
+        pipe = make_pipeline(temperature=0.0, top_p=1.0)
+        assert pipe.temperature == 0.0
+        assert pipe.top_p == 1.0
+
+
+# --- SamplingConfig ---
+
+
+class TestSamplingConfig:
+    def test_valid_sampling(self):
+        cfg = make_sampling(random_seed=42)
+        assert cfg.method == "latin_hypercube"
+        assert cfg.random_seed == 42
+
+    def test_defaults(self):
+        cfg = make_sampling()
+        assert cfg.random_seed is None
+
+    def test_invalid_method(self):
+        with pytest.raises(ValidationError):
+            SamplingConfig(method="random", optimization="maximin")
+
+    def test_invalid_optimization(self):
+        with pytest.raises(ValidationError):
+            SamplingConfig(method="latin_hypercube", optimization="random")
+
+
+# --- OracleConfig ---
+
+
+class TestOracleConfig:
+    def test_valid_oracle(self):
+        cfg = make_oracle()
+        assert cfg.type == "llm_judge"
+        assert cfg.max_tokens == 2000
+        assert cfg.temperature == 1
+
+    def test_defaults(self):
+        cfg = make_oracle()
+        assert cfg.max_tokens == 2000
+        assert cfg.temperature == 1
+
+    def test_rubric_optional(self):
+        cfg = OracleConfig(
+            type="llm_judge",
+            model="m",
+            adapter=AdapterConfig(name="ollama"),
+        )
+        assert cfg.rubric is None
+
+    def test_invalid_type(self):
+        with pytest.raises(ValidationError):
+            OracleConfig(
+                type="regex",
+                model="m",
+                adapter=AdapterConfig(name="ollama"),
+            )
+
+
+# --- BayesianAnalysisConfig ---
+
+
+class TestBayesianAnalysisConfig:
+    def test_defaults(self):
+        cfg = BayesianAnalysisConfig()
+        assert cfg.mcmc_draws == 2000
+        assert cfg.mcmc_tune == 1000
+        assert cfg.mcmc_chains == 4
+        assert cfg.prior_quality_mu == 3.0
+        assert cfg.prior_quality_sigma == 1.0
+        assert cfg.prior_noise_sigma == 0.5
+        assert cfg.hdi_probability == 0.94
+
+    def test_custom_values(self):
+        cfg = BayesianAnalysisConfig(
+            mcmc_draws=500, mcmc_tune=200, mcmc_chains=2, hdi_probability=0.89
+        )
+        assert cfg.mcmc_draws == 500
+        assert cfg.hdi_probability == 0.89
+
+    def test_draws_too_low(self):
+        with pytest.raises(ValidationError):
+            BayesianAnalysisConfig(mcmc_draws=50)
+
+    def test_tune_too_low(self):
+        with pytest.raises(ValidationError):
+            BayesianAnalysisConfig(mcmc_tune=50)
+
+    def test_chains_zero(self):
+        with pytest.raises(ValidationError):
+            BayesianAnalysisConfig(mcmc_chains=0)
+
+    def test_hdi_out_of_range(self):
+        with pytest.raises(ValidationError):
+            BayesianAnalysisConfig(hdi_probability=1.0)
+        with pytest.raises(ValidationError):
+            BayesianAnalysisConfig(hdi_probability=0.0)
+
+
+# --- SpecConfig ---
+
+
+class TestSpecConfig:
+    def test_valid_spec(self):
+        spec = SpecConfig(
+            spec_id="test-1",
+            pipeline=[make_pipeline()],
+            sampling=make_sampling(),
+            n_variants=5,
+            oracles={"judge": make_oracle()},
+        )
+        assert spec.spec_id == "test-1"
+        assert spec.n_variants == 5
+        assert len(spec.pipeline) == 1
+        assert "judge" in spec.oracles
+
+    def test_defaults(self):
+        spec = SpecConfig(
+            spec_id="test",
+            pipeline=[make_pipeline()],
+            sampling=make_sampling(),
+            oracles={"j": make_oracle()},
+        )
+        assert spec.n_variants == 1
+        assert spec.axes == []
+        assert spec.analysis is None
+
+    def test_empty_pipeline_rejected(self):
+        with pytest.raises(ValidationError):
+            SpecConfig(
+                spec_id="test",
+                pipeline=[],
+                sampling=make_sampling(),
+                oracles={"j": make_oracle()},
+            )
+
+    def test_empty_oracles_rejected(self):
+        with pytest.raises(ValidationError):
+            SpecConfig(
+                spec_id="test",
+                pipeline=[make_pipeline()],
+                sampling=make_sampling(),
+                oracles={},
+            )
+
+    def test_with_axes_and_analysis(self):
+        spec = SpecConfig(
+            spec_id="full",
+            pipeline=[make_pipeline()],
+            sampling=make_sampling(),
+            oracles={"j": make_oracle()},
+            axes=[AxisConfig(name="tone", type="categorical", values=["a", "b"])],
+            analysis=BayesianAnalysisConfig(mcmc_draws=500),
+        )
+        assert len(spec.axes) == 1
+        assert spec.analysis.mcmc_draws == 500


### PR DESCRIPTION
## Summary
- Add 27 adapter tests covering all 4 LLM adapters (Ollama, OpenAI, Anthropic, Google) and the adapter factory
- Add 33 config model tests covering all Pydantic models (AdapterConfig, AxisConfig, PipelineConfig, SamplingConfig, OracleConfig, BayesianAnalysisConfig, SpecConfig)
- All adapter SDK clients are mocked — no real API calls
- Coverage increased from 21% to 42%

## Test plan
- [x] All 71 tests pass (11 existing + 60 new)
- [x] flake8 passes clean
- [x] All pre-commit hooks pass

Closes #52