### PR TITLE
test: add oracle, pipeline, and analyzer tests

### DIFF
--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,117 @@
+import pytest
+
+from metareason.analysis.analyzer import BayesianAnalyzer
+from metareason.config.models import (
+    AdapterConfig,
+    BayesianAnalysisConfig,
+    OracleConfig,
+    PipelineConfig,
+    SamplingConfig,
+    SpecConfig,
+)
+from metareason.oracles.oracle_base import EvaluationResult
+from metareason.pipeline.runner import SampleResult
+
+
+def make_spec(**overrides):
+    defaults = dict(
+        spec_id="test",
+        pipeline=[
+            PipelineConfig(
+                template="t",
+                adapter=AdapterConfig(name="ollama"),
+                model="m",
+                temperature=0.7,
+                top_p=0.9,
+                max_tokens=100,
+            )
+        ],
+        sampling=SamplingConfig(method="latin_hypercube", optimization="maximin"),
+        oracles={
+            "test_oracle": OracleConfig(
+                type="llm_judge",
+                model="m",
+                adapter=AdapterConfig(name="ollama"),
+                rubric="test",
+            )
+        },
+    )
+    defaults.update(overrides)
+    return SpecConfig(**defaults)
+
+
+def make_results(n=5, score=3.5):
+    return [
+        SampleResult(
+            sample_params={"param": i},
+            original_prompt="test prompt",
+            final_response="test response",
+            evaluations={
+                "test_oracle": EvaluationResult(score=score, explanation="ok")
+            },
+        )
+        for i in range(n)
+    ]
+
+
+class TestBayesianAnalyzerInit:
+    def test_init_defaults(self):
+        results = make_results()
+        spec = make_spec()
+        analyzer = BayesianAnalyzer(results, spec)
+
+        assert analyzer.n_variants == 5
+        assert analyzer.analysis_config.mcmc_draws == 2000
+        assert analyzer.analysis_config.mcmc_tune == 1000
+        assert analyzer.analysis_config.mcmc_chains == 4
+
+    def test_init_custom_config(self):
+        results = make_results()
+        custom = BayesianAnalysisConfig(mcmc_draws=200, mcmc_tune=100, mcmc_chains=2)
+        spec = make_spec(analysis=custom)
+        analyzer = BayesianAnalyzer(results, spec)
+
+        assert analyzer.analysis_config.mcmc_draws == 200
+        assert analyzer.analysis_config.mcmc_tune == 100
+        assert analyzer.analysis_config.mcmc_chains == 2
+
+
+@pytest.mark.slow
+class TestBayesianAnalyzerSampling:
+    def test_estimate_population_quality_returns_expected_keys(self):
+        results = make_results(n=5, score=3.5)
+        spec = make_spec(
+            analysis=BayesianAnalysisConfig(
+                mcmc_draws=100, mcmc_tune=100, mcmc_chains=1
+            )
+        )
+        analyzer = BayesianAnalyzer(results, spec)
+        result = analyzer.estimate_population_quality("test_oracle")
+
+        expected_keys = {
+            "population_mean",
+            "population_median",
+            "hdi_lower",
+            "hdi_upper",
+            "hdi_prob",
+            "oracle_noise_mean",
+            "oracle_noise_hdi",
+            "n_samples",
+        }
+        assert set(result.keys()) == expected_keys
+        assert result["n_samples"] == 5
+        assert result["hdi_prob"] == 0.94
+
+    def test_estimate_population_quality_hdi_bounds(self):
+        results = make_results(n=5, score=3.5)
+        spec = make_spec(
+            analysis=BayesianAnalysisConfig(
+                mcmc_draws=100, mcmc_tune=100, mcmc_chains=1
+            )
+        )
+        analyzer = BayesianAnalyzer(results, spec)
+        result = analyzer.estimate_population_quality("test_oracle")
+
+        assert result["hdi_lower"] < result["hdi_upper"]
+        assert result["hdi_lower"] > 0.0
+        assert result["hdi_upper"] < 7.0

--- a/tests/test_oracles.py
+++ b/tests/test_oracles.py
@@ -1,0 +1,127 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from metareason.adapters.adapter_base import AdapterResponse
+from metareason.config.models import AdapterConfig, OracleConfig
+from metareason.oracles.llm_judge import LLMJudge
+from metareason.oracles.oracle_base import (
+    EvaluationContext,
+    EvaluationResult,
+    OracleException,
+)
+
+
+def make_oracle_config(**overrides):
+    defaults = dict(
+        type="llm_judge",
+        model="test-model",
+        adapter=AdapterConfig(name="ollama"),
+        rubric="Score 1-5 on quality",
+    )
+    defaults.update(overrides)
+    return OracleConfig(**defaults)
+
+
+@pytest.fixture
+def eval_context():
+    return EvaluationContext(
+        prompt="What is 2+2?",
+        response="The answer is 4.",
+    )
+
+
+class TestLLMJudgeInit:
+    @patch("metareason.oracles.llm_judge.get_adapter")
+    def test_init_requires_rubric(self, mock_get_adapter):
+        with pytest.raises(ValueError, match="Rubric is required"):
+            LLMJudge(make_oracle_config(rubric=None))
+
+    @patch("metareason.oracles.llm_judge.get_adapter")
+    def test_init_creates_adapter(self, mock_get_adapter):
+        mock_get_adapter.return_value = MagicMock()
+        config = make_oracle_config()
+        judge = LLMJudge(config)
+
+        mock_get_adapter.assert_called_once_with("ollama")
+        assert judge.adapter is mock_get_adapter.return_value
+        assert "Score 1-5 on quality" in judge.sys_prompt
+
+
+class TestLLMJudgeEvaluate:
+    @patch("metareason.oracles.llm_judge.get_adapter")
+    @pytest.mark.asyncio
+    async def test_evaluate_success(self, mock_get_adapter, eval_context):
+        mock_adapter = AsyncMock()
+        mock_adapter.send_request.return_value = AdapterResponse(
+            response_text=json.dumps({"score": 4, "explanation": "good"})
+        )
+        mock_get_adapter.return_value = mock_adapter
+
+        judge = LLMJudge(make_oracle_config())
+        result = await judge.evaluate(eval_context)
+
+        assert isinstance(result, EvaluationResult)
+        assert result.score == 4.0
+        assert result.explanation == "good"
+
+    @patch("metareason.oracles.llm_judge.get_adapter")
+    @pytest.mark.asyncio
+    async def test_evaluate_with_markdown_code_block(
+        self, mock_get_adapter, eval_context
+    ):
+        mock_adapter = AsyncMock()
+        mock_adapter.send_request.return_value = AdapterResponse(
+            response_text='```json\n{"score": 3, "explanation": "ok"}\n```'
+        )
+        mock_get_adapter.return_value = mock_adapter
+
+        judge = LLMJudge(make_oracle_config())
+        result = await judge.evaluate(eval_context)
+
+        assert result.score == 3.0
+        assert result.explanation == "ok"
+
+    @patch("metareason.oracles.llm_judge.get_adapter")
+    @pytest.mark.asyncio
+    async def test_evaluate_missing_score_field(self, mock_get_adapter, eval_context):
+        mock_adapter = AsyncMock()
+        mock_adapter.send_request.return_value = AdapterResponse(
+            response_text=json.dumps({"explanation": "no score"})
+        )
+        mock_get_adapter.return_value = mock_adapter
+
+        judge = LLMJudge(make_oracle_config())
+        with pytest.raises(OracleException, match="missing 'score' field"):
+            await judge.evaluate(eval_context)
+
+    @patch("metareason.oracles.llm_judge.get_adapter")
+    @pytest.mark.asyncio
+    async def test_evaluate_invalid_json(self, mock_get_adapter, eval_context):
+        mock_adapter = AsyncMock()
+        mock_adapter.send_request.return_value = AdapterResponse(
+            response_text="this is not json"
+        )
+        mock_get_adapter.return_value = mock_adapter
+
+        judge = LLMJudge(make_oracle_config())
+        with pytest.raises(OracleException, match="Invalid JSON"):
+            await judge.evaluate(eval_context)
+
+    @patch("metareason.oracles.llm_judge.get_adapter")
+    @pytest.mark.asyncio
+    async def test_evaluate_no_explanation_uses_default(
+        self, mock_get_adapter, eval_context
+    ):
+        mock_adapter = AsyncMock()
+        mock_adapter.send_request.return_value = AdapterResponse(
+            response_text=json.dumps({"score": 5})
+        )
+        mock_get_adapter.return_value = mock_adapter
+
+        judge = LLMJudge(make_oracle_config())
+        result = await judge.evaluate(eval_context)
+
+        assert result.score == 5.0
+        assert result.explanation == "No explanation provided"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,179 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from metareason.adapters.adapter_base import AdapterResponse
+from metareason.config.models import AdapterConfig, PipelineConfig
+from metareason.oracles.oracle_base import EvaluationResult
+from metareason.pipeline.loader import load_spec
+from metareason.pipeline.renderer import TemplateRenderer
+from metareason.pipeline.runner import SampleResult, _process_sample
+
+# --- TemplateRenderer ---
+
+
+class TestTemplateRenderer:
+    def test_render_simple_template(self):
+        renderer = TemplateRenderer()
+        result = renderer.render_request("Hello {{ name }}", {"name": "World"})
+        assert result == "Hello World"
+
+    def test_render_multiple_variables(self):
+        renderer = TemplateRenderer()
+        template = "{{ greeting }}, {{ name }}! You are {{ age }} years old."
+        variables = {"greeting": "Hi", "name": "Alice", "age": 30}
+        result = renderer.render_request(template, variables)
+        assert result == "Hi, Alice! You are 30 years old."
+
+    def test_render_missing_variable(self):
+        renderer = TemplateRenderer()
+        result = renderer.render_request(
+            "Hello {{ name }} and {{ missing }}", {"name": "World"}
+        )
+        assert result == "Hello World and "
+
+
+# --- load_spec ---
+
+
+class TestLoadSpec:
+    def test_load_valid_spec(self, tmp_path):
+        spec_yaml = tmp_path / "spec.yaml"
+        spec_yaml.write_text(
+            """
+spec_id: test-spec
+pipeline:
+  - template: "Hello {{ name }}"
+    adapter:
+      name: ollama
+    model: llama2
+    temperature: 0.7
+    top_p: 0.9
+    max_tokens: 100
+sampling:
+  method: latin_hypercube
+  optimization: maximin
+n_variants: 3
+oracles:
+  judge:
+    type: llm_judge
+    model: llama2
+    adapter:
+      name: ollama
+    rubric: "Score 1-5"
+"""
+        )
+        spec = load_spec(spec_yaml)
+        assert spec.spec_id == "test-spec"
+        assert spec.n_variants == 3
+        assert len(spec.pipeline) == 1
+        assert "judge" in spec.oracles
+
+    def test_load_invalid_spec(self, tmp_path):
+        spec_yaml = tmp_path / "bad.yaml"
+        spec_yaml.write_text(
+            """
+spec_id: test
+pipeline: []
+sampling:
+  method: latin_hypercube
+  optimization: maximin
+oracles: {}
+"""
+        )
+        with pytest.raises(ValidationError):
+            load_spec(spec_yaml)
+
+
+# --- _process_sample ---
+
+
+def make_pipeline_config(**overrides):
+    defaults = dict(
+        template="Hello {{ name }}",
+        adapter=AdapterConfig(name="ollama"),
+        model="test-model",
+        temperature=0.7,
+        top_p=0.9,
+        max_tokens=100,
+    )
+    defaults.update(overrides)
+    return PipelineConfig(**defaults)
+
+
+class TestProcessSample:
+    @patch("metareason.pipeline.runner.get_adapter")
+    @pytest.mark.asyncio
+    async def test_single_stage(self, mock_get_adapter):
+        mock_adapter = AsyncMock()
+        mock_adapter.send_request.return_value = AdapterResponse(
+            response_text="LLM response"
+        )
+        mock_get_adapter.return_value = mock_adapter
+
+        mock_oracle = AsyncMock()
+        mock_oracle.evaluate.return_value = EvaluationResult(
+            score=4.0, explanation="good"
+        )
+
+        pipeline = [make_pipeline_config()]
+        sample = {"name": "World"}
+        oracles = {"test_oracle": mock_oracle}
+
+        result = await _process_sample(pipeline, sample, oracles)
+
+        assert isinstance(result, SampleResult)
+        assert result.original_prompt == "Hello World"
+        assert result.final_response == "LLM response"
+        assert result.evaluations["test_oracle"].score == 4.0
+        assert result.sample_params == {"name": "World"}
+
+    @patch("metareason.pipeline.runner.get_adapter")
+    @pytest.mark.asyncio
+    async def test_oracle_failure_continues(self, mock_get_adapter):
+        mock_adapter = AsyncMock()
+        mock_adapter.send_request.return_value = AdapterResponse(
+            response_text="LLM response"
+        )
+        mock_get_adapter.return_value = mock_adapter
+
+        mock_oracle = AsyncMock()
+        mock_oracle.evaluate.side_effect = RuntimeError("oracle broke")
+
+        pipeline = [make_pipeline_config()]
+        sample = {"name": "World"}
+        oracles = {"failing_oracle": mock_oracle}
+
+        result = await _process_sample(pipeline, sample, oracles)
+
+        assert result.evaluations["failing_oracle"].score == 1.0
+        assert "Evaluation failed" in result.evaluations["failing_oracle"].explanation
+
+    @patch("metareason.pipeline.runner.get_adapter")
+    @pytest.mark.asyncio
+    async def test_multi_stage(self, mock_get_adapter):
+        mock_adapter = AsyncMock()
+        mock_adapter.send_request.side_effect = [
+            AdapterResponse(response_text="stage 1 output"),
+            AdapterResponse(response_text="stage 2 output"),
+        ]
+        mock_get_adapter.return_value = mock_adapter
+
+        pipeline = [
+            make_pipeline_config(template="First: {{ name }}"),
+            make_pipeline_config(template="ignored"),
+        ]
+        sample = {"name": "Test"}
+        oracles = {}
+
+        result = await _process_sample(pipeline, sample, oracles)
+
+        assert result.original_prompt == "First: Test"
+        assert result.final_response == "stage 2 output"
+
+        # Verify the second call used the first stage's output as user_prompt
+        calls = mock_adapter.send_request.call_args_list
+        assert len(calls) == 2
+        second_call_request = calls[1].args[0]
+        assert second_call_request.user_prompt == "stage 1 output"


### PR DESCRIPTION
## Summary
- Add 7 oracle tests covering LLM Judge init validation and evaluation (JSON parsing, markdown code blocks, error handling)
- Add 8 pipeline tests covering template renderer, spec loader, and pipeline runner (multi-stage, oracle failure recovery)
- Add 4 analyzer tests covering Bayesian init and population quality estimation with real PyMC sampling
- Coverage increased from 42% to 60%

## Test plan
- [x] All 90 tests pass (71 existing + 19 new)
- [x] flake8 passes clean
- [x] All pre-commit hooks pass
- [x] Bayesian tests use minimal sampling (100 draws, 1 chain) for speed

Closes #53