### PR TITLE
feat: add retry logic and timeouts to all LLM adapters

### DIFF
--- a/src/metareason/adapters/adapter_base.py
+++ b/src/metareason/adapters/adapter_base.py
@@ -3,6 +3,9 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
+DEFAULT_TIMEOUT = 30  # seconds
+DEFAULT_MAX_RETRIES = 3
+
 
 class AdapterException(Exception):
     """Base exception for adapter-related errors."""


### PR DESCRIPTION
## Summary
- Add tenacity retry with exponential jitter backoff to all 4 LLM adapters
- Add configurable timeout (30s default) to all adapter clients
- OpenAI/Anthropic: retry on `RateLimitError` and `APIConnectionError`
- Ollama: retry on `RequestError`, `ConnectionError`, `ConnectError`
- Google: custom retry predicate for 429/5xx status codes, `asyncio.wait_for` timeout
- Constants `DEFAULT_TIMEOUT=30` and `DEFAULT_MAX_RETRIES=3` in `adapter_base.py`
- Add 4 retry behavior tests verifying retry-then-succeed and retry-exhausted patterns

## Test plan
- [x] All 104 tests pass
- [x] flake8 passes clean
- [x] All pre-commit hooks pass
- [x] Coverage remains at 80%

Closes #58