### PR TITLE
fix: accept both low/high and min/max for distribution bounds

### DIFF
--- a/src/metareason/sampling/lhs_sampler.py
+++ b/src/metareason/sampling/lhs_sampler.py
@@ -100,8 +100,9 @@ class LhsSampler:
         params = axis.params or {}
 
         if distribution == "uniform":
-            min_val = params.get("min", 0.0)
-            max_val = params.get("max", 1.0)
+            self._warn_duplicate_bound_keys(params, axis.name)
+            min_val = params.get("low", params.get("min", 0.0))
+            max_val = params.get("high", params.get("max", 1.0))
             return min_val + uniform_samples * (max_val - min_val)
 
         elif distribution == "normal":
@@ -112,8 +113,9 @@ class LhsSampler:
         elif distribution == "truncnorm":
             mu = params.get("mu", 0.0)
             sigma = params.get("sigma", 1.0)
-            min_val = params.get("min", -2.0)
-            max_val = params.get("max", 2.0)
+            self._warn_duplicate_bound_keys(params, axis.name)
+            min_val = params.get("low", params.get("min", -2.0))
+            max_val = params.get("high", params.get("max", 2.0))
 
             a = (min_val - mu) / sigma
             b = (max_val - mu) / sigma
@@ -128,6 +130,17 @@ class LhsSampler:
 
         else:
             raise ValueError(f"Unknown distribution: {distribution}")
+
+    @staticmethod
+    def _warn_duplicate_bound_keys(params: dict, axis_name: str) -> None:
+        if "low" in params and "min" in params:
+            logger.warning(
+                f"Axis '{axis_name}': both 'low' and 'min' provided; using 'low'"
+            )
+        if "high" in params and "max" in params:
+            logger.warning(
+                f"Axis '{axis_name}': both 'high' and 'max' provided; using 'high'"
+            )
 
     def _generate_categorical_samples(self, n_samples: int) -> np.ndarray:
         if not self.categorical_axes:


### PR DESCRIPTION
## Summary

Closes #91

- LHS sampler now accepts both `low`/`high` (scipy convention, documented in config) and `min`/`max` (backward compat) for uniform and truncnorm distribution bounds
- `low`/`high` takes precedence when both are provided, with a warning logged
- Previously, example specs using `low`/`high` were silently ignored, causing all uniform samples to fall in `[0, 1]` regardless of user config

## Test plan

- [x] `test_uniform_distribution_accepts_low_high` — primary fix verification
- [x] `test_uniform_distribution_accepts_min_max` — backward compatibility
- [x] `test_truncnorm_distribution_accepts_low_high` — truncnorm consistency
- [x] `test_truncnorm_distribution_accepts_min_max` — truncnorm backward compat
- [x] `test_uniform_conflicting_keys_prefers_low_high` — conflict resolution + warning
- [x] Full suite: 156 passed, 86.92% coverage