### PR TITLE
fix: make OracleBase.evaluate an async method (#92)

### DIFF
--- a/src/metareason/oracles/oracle_base.py
+++ b/src/metareason/oracles/oracle_base.py
@@ -35,7 +35,7 @@ class OracleBase(ABC):
         self.config = config
 
     @abstractmethod
-    def evaluate(self, request: EvaluationContext) -> EvaluationResult:
+    async def evaluate(self, request: EvaluationContext) -> EvaluationResult:
         """Evaluate an LLM response.
 
         Args:

--- a/tests/test_oracles.py
+++ b/tests/test_oracles.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,8 +10,15 @@ from metareason.oracles.llm_judge import LLMJudge
 from metareason.oracles.oracle_base import (
     EvaluationContext,
     EvaluationResult,
+    OracleBase,
     OracleException,
 )
+
+
+class TestOracleBaseContract:
+    def test_evaluate_is_coroutine_function(self):
+        """OracleBase.evaluate must be declared as an async method."""
+        assert inspect.iscoroutinefunction(OracleBase.evaluate)
 
 
 def make_oracle_config(**overrides):


### PR DESCRIPTION
## Summary
- Changes `OracleBase.evaluate()` from sync to `async def` to match how it's actually called
- Ensures consistency with the async pipeline execution model

Closes #92