### PR TITLE
fix: disable Jinja2 autoescape for LLM prompt templates (#94)

### DIFF
--- a/src/metareason/pipeline/renderer.py
+++ b/src/metareason/pipeline/renderer.py
@@ -9,7 +9,7 @@ class TemplateRenderer:
             trim_blocks=True,
             lstrip_blocks=True,
             keep_trailing_newline=False,
-            autoescape=True,
+            autoescape=False,  # nosec B701 - renders LLM prompts, not HTML
         )
 
     def render_request(self, template: str, variables: Dict[str, Any]) -> str:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -26,6 +26,17 @@ class TestTemplateRenderer:
         result = renderer.render_request(template, variables)
         assert result == "Hi, Alice! You are 30 years old."
 
+    def test_render_special_characters_not_escaped(self):
+        """Prompt templates should NOT HTML-escape special characters (issue #94)."""
+        renderer = TemplateRenderer()
+        result = renderer.render_request(
+            "Compare: {{ comparison }}", {"comparison": "5 > 3"}
+        )
+        assert result == "Compare: 5 > 3"
+        assert "&gt;" not in result
+        assert "&lt;" not in result
+        assert "&amp;" not in result
+
     def test_render_missing_variable(self):
         renderer = TemplateRenderer()
         result = renderer.render_request(


### PR DESCRIPTION
## Summary
- Sets `autoescape=False` in TemplateRenderer's Jinja2 Environment
- Prevents HTML entity escaping in LLM prompts (e.g., `&amp;` instead of `&`)
- Added `# nosec B701` annotation for bandit security scanner

Closes #94