### PR TITLE
fix: remove unused dependencies from pyproject.toml (#98)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,24 +28,18 @@ dependencies = [
     "numpy>=1.24,<2.0",  # Numerical computing
     "scipy>=1.11,<2.0",  # Scientific computing
     "pydantic>=2.0,<3.0",  # Configuration validation
-    "pydantic-settings>=2.0,<3.0",  # Settings management
     "click>=8.1,<9.0",  # CLI framework
     "pyyaml>=6.0,<7.0",  # Configuration parsing
     "jinja2>=3.1,<4.0",  # Template rendering
     "httpx>=0.25,<1.0",  # Async HTTP client
     "matplotlib>=3.8,<4.0",  # Visualization
-    "seaborn>=0.13,<1.0",  # Statistical visualization
     # Additional useful dependencies
     "rich>=13.0,<14.0",  # Rich terminal output
-    "pandas>=2.0,<3.0",  # Data manipulation
-    "tqdm>=4.66,<5.0",  # Progress bars
-    "aiohttp>=3.9,<4.0",  # Async HTTP server/client
     "ollama>=0.5,<1.0",  # Ollama API client
     "openai>=1.0,<2.0",  # Official OpenAI API client
     "anthropic>=0.34,<1.0",  # Official Anthropic API client
     "google-genai>=1.0,<2.0",  # Official Google GenAI SDK for Gemini
     "tenacity>=8.2,<9.0",  # Retry logic
-    "structlog>=24.0,<25.0",  # Structured logging
     "python-dotenv>=1.0,<2.0",  # Environment variable management
 ]
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,53 @@
+"""Verify metareason imports after removing unused dependencies."""
+
+import pathlib
+
+
+def test_metareason_imports_successfully():
+    """Verify that the main metareason package can be imported."""
+    import metareason
+
+    assert metareason is not None
+
+
+def test_core_submodules_import():
+    """Verify that core submodules import without error."""
+    from metareason.config import models
+    from metareason.pipeline import renderer
+    from metareason.sampling import lhs_sampler
+
+    assert models is not None
+    assert lhs_sampler is not None
+    assert renderer is not None
+
+
+def test_no_direct_imports_of_removed_packages():
+    """Verify no source file imports removed unused dependencies."""
+    removed_packages = [
+        "seaborn",
+        "tqdm",
+        "aiohttp",
+        "structlog",
+        "pydantic_settings",
+        "pandas",
+    ]
+
+    src_dir = pathlib.Path(__file__).parent.parent / "src" / "metareason"
+    violations = []
+
+    for py_file in src_dir.rglob("*.py"):
+        content = py_file.read_text()
+        for pkg in removed_packages:
+            for line in content.splitlines():
+                stripped = line.strip()
+                if stripped.startswith("#"):
+                    continue
+                if f"import {pkg}" in stripped or f"from {pkg}" in stripped:
+                    violations.append(
+                        f"{py_file.relative_to(src_dir)}: {stripped} "
+                        f"(uses removed dependency '{pkg}')"
+                    )
+
+    assert (
+        not violations
+    ), "Found direct imports of removed dependencies:\n" + "\n".join(violations)


### PR DESCRIPTION
## Summary
- Removes seaborn, tqdm, aiohttp, structlog, pydantic-settings, and pandas
- These were declared in pyproject.toml but never imported in the codebase
- Adds tests verifying no source files import removed packages

Closes #98