### PR TITLE
fix: export all adapter classes from adapters package (#100)

### DIFF
--- a/src/metareason/adapters/__init__.py
+++ b/src/metareason/adapters/__init__.py
@@ -1,14 +1,18 @@
 from .adapter_base import AdapterBase, AdapterException, AdapterRequest, AdapterResponse
 from .adapter_factory import get_adapter
+from .anthropic import AnthropicAdapter
 from .google import GoogleAdapter
 from .ollama import OllamaAdapter
+from .openai import OpenAIAdapter
 
 __all__ = [
     "AdapterBase",
     "AdapterException",
     "AdapterRequest",
     "AdapterResponse",
-    "OllamaAdapter",
+    "AnthropicAdapter",
     "GoogleAdapter",
+    "OllamaAdapter",
+    "OpenAIAdapter",
     "get_adapter",
 ]

--- a/tests/test_adapter_exports.py
+++ b/tests/test_adapter_exports.py
@@ -1,0 +1,45 @@
+"""Test that all adapter classes are exported from the adapters package."""
+
+
+def test_all_adapters_importable_from_package():
+    """All adapter classes should be importable from metareason.adapters."""
+    from metareason.adapters import (
+        AdapterBase,
+        AdapterException,
+        AdapterRequest,
+        AdapterResponse,
+        AnthropicAdapter,
+        GoogleAdapter,
+        OllamaAdapter,
+        OpenAIAdapter,
+        get_adapter,
+    )
+
+    assert AnthropicAdapter is not None
+    assert OpenAIAdapter is not None
+    assert GoogleAdapter is not None
+    assert OllamaAdapter is not None
+    assert AdapterBase is not None
+    assert AdapterException is not None
+    assert AdapterRequest is not None
+    assert AdapterResponse is not None
+    assert get_adapter is not None
+
+
+def test_all_list_contains_all_adapters():
+    """The __all__ list should contain all adapter classes."""
+    import metareason.adapters as adapters_pkg
+
+    expected = [
+        "AdapterBase",
+        "AdapterException",
+        "AdapterRequest",
+        "AdapterResponse",
+        "AnthropicAdapter",
+        "GoogleAdapter",
+        "OllamaAdapter",
+        "OpenAIAdapter",
+        "get_adapter",
+    ]
+    for name in expected:
+        assert name in adapters_pkg.__all__, f"{name} missing from __all__"


### PR DESCRIPTION
## Summary
- Adds AnthropicAdapter and OpenAIAdapter to `metareason.adapters.__init__.py`
- Updates `__all__` to include all adapter classes
- Adds tests verifying all adapters are importable from the package

Closes #100