### PR TITLE
fix: reframe calibration around judge behavior instead of response qu…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,7 @@ The project has the following structure:
 
 - **Review and suggest**: Provide code reviews, answer technical questions, and suggest best practices when asked
 - **No proactive coding**: Do not write implementation code unless explicitly requested
+- **No unrequested actions**: Do not take actions (file edits, code changes, refactors) the user hasn't asked for. Discuss first, act only when told to
 - **Explain and guide**: Focus on explaining concepts, pointing out issues, and providing guidance
 - **Keyboard-first workflow**: Support the user's goal of staying on the keyboard and minimizing mouse usage
 

--- a/examples/multi_judge_calibration.yml
+++ b/examples/multi_judge_calibration.yml
@@ -1,0 +1,59 @@
+spec_id: multi_judge_calibration_v1
+type: calibrate_multi
+prompt: "Explain the concept of quantum entanglement to a college student."
+response: |
+  Quantum entanglement is a phenomenon in quantum physics where two particles
+  become connected in such a way that measuring one instantly affects the other,
+  regardless of distance. Think of it like having two magic coins - when you
+  flip them, no matter how far apart they are, if one lands heads, the other
+  always lands tails. Einstein called this "spooky action at a distance"
+  because it seemed to violate the speed of light limit. But it's important
+  to note that you can't actually use entanglement to send information faster
+  than light. The correlation only becomes apparent when you compare the
+  measurements afterward.
+expected_score: 4
+repeats: 30
+oracles:
+  gpt4o_judge:
+    type: llm_judge
+    model: gpt-4o
+    adapter:
+      name: openai
+    rubric: |
+      Evaluate the response for coherence and clarity on a 1-5 scale:
+      1 = Completely incoherent or wrong
+      2 = Mostly unclear or contains significant errors
+      3 = Somewhat clear but has notable issues
+      4 = Clear and mostly accurate
+      5 = Exceptionally clear, accurate, and well-explained
+      Return JSON: {"score": X, "explanation": "..."}
+  claude_judge:
+    type: llm_judge
+    model: claude-sonnet-4-20250514
+    adapter:
+      name: anthropic
+    rubric: |
+      Evaluate the response for coherence and clarity on a 1-5 scale:
+      1 = Completely incoherent or wrong
+      2 = Mostly unclear or contains significant errors
+      3 = Somewhat clear but has notable issues
+      4 = Clear and mostly accurate
+      5 = Exceptionally clear, accurate, and well-explained
+      Return JSON: {"score": X, "explanation": "..."}
+  gemma_judge:
+    type: llm_judge
+    model: gemma3:27b
+    adapter:
+      name: ollama
+    rubric: |
+      Evaluate the response for coherence and clarity on a 1-5 scale:
+      1 = Completely incoherent or wrong
+      2 = Mostly unclear or contains significant errors
+      3 = Somewhat clear but has notable issues
+      4 = Clear and mostly accurate
+      5 = Exceptionally clear, accurate, and well-explained
+      Return JSON: {"score": X, "explanation": "..."}
+analysis:
+  hdi_probability: 0.94
+  mcmc_draws: 2000
+  mcmc_chains: 4

--- a/examples/multi_judge_ollama.yml
+++ b/examples/multi_judge_ollama.yml
@@ -1,0 +1,62 @@
+spec_id: multi_judge_ollama_test
+type: calibrate_multi
+prompt: "Explain the concept of quantum entanglement to a college student."
+response: |
+  Quantum entanglement is a phenomenon in quantum physics where two particles
+  become connected in such a way that measuring one instantly affects the other,
+  regardless of distance. Think of it like having two magic coins - when you
+  flip them, no matter how far apart they are, if one lands heads, the other
+  always lands tails. Einstein called this "spooky action at a distance"
+  because it seemed to violate the speed of light limit. But it's important
+  to note that you can't actually use entanglement to send information faster
+  than light. The correlation only becomes apparent when you compare the
+  measurements afterward.
+expected_score: 4
+repeats: 10
+oracles:
+  qwen3_judge:
+    type: llm_judge
+    model: qwen3:30b
+    adapter:
+      name: ollama
+    temperature: 0.7
+    rubric: |
+      Evaluate the response for coherence and clarity on a 1-5 scale:
+      1 = Completely incoherent or wrong
+      2 = Mostly unclear or contains significant errors
+      3 = Somewhat clear but has notable issues
+      4 = Clear and mostly accurate
+      5 = Exceptionally clear, accurate, and well-explained
+      Return JSON: {"score": X, "explanation": "..."}
+  gemma3_judge:
+    type: llm_judge
+    model: gemma3:27b
+    adapter:
+      name: ollama
+    temperature: 0.7
+    rubric: |
+      Evaluate the response for coherence and clarity on a 1-5 scale:
+      1 = Completely incoherent or wrong
+      2 = Mostly unclear or contains significant errors
+      3 = Somewhat clear but has notable issues
+      4 = Clear and mostly accurate
+      5 = Exceptionally clear, accurate, and well-explained
+      Return JSON: {"score": X, "explanation": "..."}
+  gptoss_judge:
+    type: llm_judge
+    model: gpt-oss:20b
+    adapter:
+      name: ollama
+    temperature: 0.7
+    rubric: |
+      Evaluate the response for coherence and clarity on a 1-5 scale:
+      1 = Completely incoherent or wrong
+      2 = Mostly unclear or contains significant errors
+      3 = Somewhat clear but has notable issues
+      4 = Clear and mostly accurate
+      5 = Exceptionally clear, accurate, and well-explained
+      Return JSON: {"score": X, "explanation": "..."}
+analysis:
+  hdi_probability: 0.94
+  mcmc_draws: 2000
+  mcmc_chains: 4

--- a/src/metareason/analysis/__init__.py
+++ b/src/metareason/analysis/__init__.py
@@ -1,0 +1,13 @@
+from .agreement import (
+    compute_agreement_summary,
+    compute_krippendorff_alpha,
+    compute_pairwise_correlations,
+    extract_scores_by_oracle,
+)
+
+__all__ = [
+    "compute_agreement_summary",
+    "compute_krippendorff_alpha",
+    "compute_pairwise_correlations",
+    "extract_scores_by_oracle",
+]

--- a/src/metareason/analysis/agreement.py
+++ b/src/metareason/analysis/agreement.py
@@ -1,0 +1,201 @@
+import warnings
+from itertools import combinations
+from typing import Dict, List, Optional
+
+import numpy as np
+from scipy.stats import pearsonr, spearmanr
+
+from metareason.pipeline.runner import SampleResult
+
+
+def compute_pairwise_correlations(
+    scores_by_oracle: Dict[str, List[float]],
+) -> dict:
+    """Pairwise Pearson and Spearman correlations between judges.
+
+    Returns dict with 'pearson' and 'spearman' sub-dicts mapping
+    (oracle_a, oracle_b) tuple keys to correlation coefficients.
+    """
+    names = list(scores_by_oracle.keys())
+    pearson_corrs = {}
+    spearman_corrs = {}
+
+    for a, b in combinations(names, 2):
+        scores_a = scores_by_oracle[a]
+        scores_b = scores_by_oracle[b]
+
+        # Only use indices where both have values
+        paired = [
+            (sa, sb)
+            for sa, sb in zip(scores_a, scores_b)
+            if sa is not None and sb is not None
+        ]
+
+        if len(paired) < 3:
+            pearson_corrs[(a, b)] = None
+            spearman_corrs[(a, b)] = None
+            continue
+
+        arr_a = [p[0] for p in paired]
+        arr_b = [p[1] for p in paired]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            r_pearson, _ = pearsonr(arr_a, arr_b)
+            r_spearman, _ = spearmanr(arr_a, arr_b)
+
+        pearson_corrs[(a, b)] = None if np.isnan(r_pearson) else float(r_pearson)
+        spearman_corrs[(a, b)] = None if np.isnan(r_spearman) else float(r_spearman)
+
+    return {"pearson": pearson_corrs, "spearman": spearman_corrs}
+
+
+def compute_krippendorff_alpha(
+    scores_by_oracle: Dict[str, List[Optional[float]]],
+    level_of_measurement: str = "interval",
+) -> float:
+    """Krippendorff's alpha for inter-rater reliability.
+
+    Implements the algorithm directly using numpy.
+    Handles missing data (None values). Returns alpha in [-1, 1].
+    """
+    oracle_names = list(scores_by_oracle.keys())
+    n_units = max(len(v) for v in scores_by_oracle.values())
+    n_coders = len(oracle_names)
+
+    # Build reliability data matrix: coders x units
+    # NaN for missing data
+    data = np.full((n_coders, n_units), np.nan)
+    for i, name in enumerate(oracle_names):
+        scores = scores_by_oracle[name]
+        for j, s in enumerate(scores):
+            if s is not None:
+                data[i, j] = s
+
+    # Difference function for interval data
+    def _diff_sq(v1, v2):
+        return (v1 - v2) ** 2
+
+    # Observed disagreement (D_o)
+    # For each unit, compute pairwise disagreements among coders who rated it
+    d_o_num = 0.0
+    d_o_den = 0.0
+
+    for u in range(n_units):
+        values = data[:, u]
+        valid = values[~np.isnan(values)]
+        m_u = len(valid)
+        if m_u < 2:
+            continue
+        # All pairs within this unit
+        for i in range(m_u):
+            for j in range(i + 1, m_u):
+                d_o_num += _diff_sq(valid[i], valid[j])
+        d_o_den += m_u - 1
+
+    if d_o_den == 0:
+        return 1.0  # No valid pairs at all
+
+    D_o = d_o_num / d_o_den
+
+    # Expected disagreement (D_e)
+    # Collect all values with their unit weights
+    all_values = []
+    weights = []
+    for u in range(n_units):
+        values = data[:, u]
+        valid = values[~np.isnan(values)]
+        m_u = len(valid)
+        if m_u < 2:
+            continue
+        for v in valid:
+            all_values.append(v)
+            weights.append(1.0)  # each value contributes equally
+
+    all_values = np.array(all_values)
+    n_total = len(all_values)
+
+    if n_total < 2:
+        return 1.0
+
+    d_e_num = 0.0
+    for i in range(n_total):
+        for j in range(i + 1, n_total):
+            d_e_num += _diff_sq(all_values[i], all_values[j])
+
+    D_e = d_e_num / (n_total - 1)
+
+    if D_e == 0:
+        return 1.0  # Perfect agreement (all values identical)
+
+    alpha = 1.0 - D_o / D_e
+    return float(alpha)
+
+
+def compute_agreement_summary(
+    scores_by_oracle: Dict[str, List[Optional[float]]],
+) -> dict:
+    """Full agreement summary: alpha + pairwise correlations + means."""
+    # Filter to non-None scores for correlations
+    clean_scores = {}
+    for name, scores in scores_by_oracle.items():
+        clean_scores[name] = [s for s in scores if s is not None]
+
+    correlations = compute_pairwise_correlations(scores_by_oracle)
+    alpha = compute_krippendorff_alpha(scores_by_oracle)
+
+    # Per-oracle means and stds
+    oracle_stats = {}
+    for name, scores in clean_scores.items():
+        if scores:
+            oracle_stats[name] = {
+                "mean": float(np.mean(scores)),
+                "std": float(np.std(scores)),
+                "n": len(scores),
+            }
+
+    # Mean pairwise correlations
+    pearson_vals = [v for v in correlations["pearson"].values() if v is not None]
+    spearman_vals = [v for v in correlations["spearman"].values() if v is not None]
+
+    return {
+        "krippendorff_alpha": alpha,
+        "pairwise_correlations": {
+            "pearson": {
+                f"{k[0]}_vs_{k[1]}": v for k, v in correlations["pearson"].items()
+            },
+            "spearman": {
+                f"{k[0]}_vs_{k[1]}": v for k, v in correlations["spearman"].items()
+            },
+        },
+        "mean_pearson": float(np.mean(pearson_vals)) if pearson_vals else None,
+        "mean_spearman": float(np.mean(spearman_vals)) if spearman_vals else None,
+        "oracle_stats": oracle_stats,
+        "n_judges": len(scores_by_oracle),
+    }
+
+
+def extract_scores_by_oracle(
+    results: List[SampleResult],
+) -> Dict[str, List[Optional[float]]]:
+    """Extract per-oracle score lists from SampleResult objects.
+
+    Returns None for missing evaluations (handles ragged data).
+    """
+    # Collect all oracle names across all results
+    all_oracle_names = set()
+    for r in results:
+        all_oracle_names.update(r.evaluations.keys())
+
+    scores_by_oracle: Dict[str, List[Optional[float]]] = {
+        name: [] for name in sorted(all_oracle_names)
+    }
+
+    for r in results:
+        for name in scores_by_oracle:
+            if name in r.evaluations:
+                scores_by_oracle[name].append(r.evaluations[name].score)
+            else:
+                scores_by_oracle[name].append(None)
+
+    return scores_by_oracle

--- a/src/metareason/analysis/analyzer.py
+++ b/src/metareason/analysis/analyzer.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import arviz as az
 import numpy as np
@@ -185,6 +185,103 @@ class BayesianAnalyzer:
             "n_samples": len(scores),
         }
 
+    def estimate_judge_calibration(
+        self,
+        oracle_name: str,
+        expected_score: Optional[float] = None,
+        hdi_prob: float = 0.94,
+    ) -> dict:
+        """Estimate judge bias and noise for calibration.
+
+        With expected_score: estimates judge_bias and judge_noise, anchored to
+        the known score. Without: estimates true_quality (as nuisance) and
+        judge_noise; bias is not identifiable without a reference point.
+
+        Args:
+            oracle_name: Name of the oracle to analyze.
+            expected_score: Known ground-truth score, if available.
+            hdi_prob: Probability mass for credible intervals.
+
+        Returns:
+            Dict with judge-focused calibration results.
+        """
+        scores = np.array([r.evaluations[oracle_name].score for r in self.results])
+
+        with pm.Model():
+            if expected_score is not None:
+                judge_bias = pm.Normal(
+                    "judge_bias",
+                    mu=0,
+                    sigma=self.analysis_config.prior_bias_sigma,
+                )
+                judge_noise = pm.HalfNormal(
+                    "judge_noise", sigma=self.analysis_config.prior_noise_sigma
+                )
+                pm.Normal(
+                    "observed",
+                    mu=expected_score + judge_bias,
+                    sigma=judge_noise,
+                    observed=scores,
+                )
+            else:
+                true_quality = pm.Normal(
+                    "true_quality",
+                    mu=self.analysis_config.prior_quality_mu,
+                    sigma=self.analysis_config.prior_quality_sigma,
+                )
+                judge_noise = pm.HalfNormal(
+                    "judge_noise", sigma=self.analysis_config.prior_noise_sigma
+                )
+                pm.Normal(
+                    "observed",
+                    mu=true_quality,
+                    sigma=judge_noise,
+                    observed=scores,
+                )
+
+            trace = pm.sample(
+                draws=self.analysis_config.mcmc_draws,
+                tune=self.analysis_config.mcmc_tune,
+                chains=self.analysis_config.mcmc_chains,
+            )
+
+        posterior = trace.posterior
+        noise_samples = posterior["judge_noise"].values.flatten()
+        noise_hdi = az.hdi(trace, var_names=["judge_noise"], hdi_prob=hdi_prob)
+
+        result = {
+            "noise_mean": float(noise_samples.mean()),
+            "noise_hdi": (
+                float(noise_hdi["judge_noise"].values[0]),
+                float(noise_hdi["judge_noise"].values[1]),
+            ),
+            "n_samples": len(scores),
+            "hdi_prob": hdi_prob,
+            "raw_score_mean": float(scores.mean()),
+            "raw_score_std": float(scores.std()),
+        }
+
+        if expected_score is not None:
+            bias_samples = posterior["judge_bias"].values.flatten()
+            bias_hdi = az.hdi(trace, var_names=["judge_bias"], hdi_prob=hdi_prob)
+            result["expected_score"] = expected_score
+            result["bias_mean"] = float(bias_samples.mean())
+            result["bias_median"] = float(np.median(bias_samples))
+            result["bias_hdi"] = (
+                float(bias_hdi["judge_bias"].values[0]),
+                float(bias_hdi["judge_bias"].values[1]),
+            )
+        else:
+            quality_samples = posterior["true_quality"].values.flatten()
+            quality_hdi = az.hdi(trace, var_names=["true_quality"], hdi_prob=hdi_prob)
+            result["estimated_quality_mean"] = float(quality_samples.mean())
+            result["estimated_quality_hdi"] = (
+                float(quality_hdi["true_quality"].values[0]),
+                float(quality_hdi["true_quality"].values[1]),
+            )
+
+        return result
+
     def _build_design_matrix(self, oracle_name: str, axes: List[AxisConfig]) -> tuple:
         """Build design matrix from sample params and axis configs.
 
@@ -355,3 +452,155 @@ class BayesianAnalyzer:
             "n_predictors": X.shape[1],
             "hdi_prob": hdi_prob,
         }
+
+    def estimate_multi_judge_quality(
+        self,
+        oracle_names: List[str],
+        hdi_prob: float = 0.94,
+        expected_score: Optional[float] = None,
+    ) -> dict:
+        """Estimate judge calibration from multiple judges using a hierarchical model.
+
+        With expected_score: anchors to the known score and drops true_quality.
+        Without: keeps true_quality as a nuisance parameter.
+
+        In both cases, per-judge bias and noise are the primary outputs.
+
+        Args:
+            oracle_names: List of oracle names to include in the model.
+            hdi_prob: Probability mass for credible intervals.
+            expected_score: Known ground-truth score, if available.
+
+        Returns:
+            Dict with per-judge bias/noise/consistency_weight, and optionally
+            true quality estimates (when expected_score is not provided).
+        """
+        # Build flat arrays with judge index mapping
+        scores_flat = []
+        judge_idx = []
+        per_judge_scores = {}
+
+        for j, name in enumerate(oracle_names):
+            oracle_scores = [
+                r.evaluations[name].score for r in self.results if name in r.evaluations
+            ]
+            per_judge_scores[name] = oracle_scores
+            scores_flat.extend(oracle_scores)
+            judge_idx.extend([j] * len(oracle_scores))
+
+        scores_array = np.array(scores_flat)
+        judge_idx_array = np.array(judge_idx, dtype=int)
+        n_judges = len(oracle_names)
+
+        with pm.Model():
+            if expected_score is not None:
+                anchor = expected_score
+            else:
+                true_quality = pm.Normal(
+                    "true_quality",
+                    mu=self.analysis_config.prior_quality_mu,
+                    sigma=self.analysis_config.prior_quality_sigma,
+                )
+                anchor = true_quality
+
+            bias = pm.Normal(
+                "bias",
+                mu=0,
+                sigma=self.analysis_config.prior_bias_sigma,
+                shape=n_judges,
+            )
+
+            noise = pm.HalfNormal(
+                "noise",
+                sigma=self.analysis_config.prior_noise_sigma,
+                shape=n_judges,
+            )
+
+            mu = anchor + bias[judge_idx_array]
+            sigma = noise[judge_idx_array]
+
+            pm.Normal("observed", mu=mu, sigma=sigma, observed=scores_array)
+
+            trace = pm.sample(
+                draws=self.analysis_config.mcmc_draws,
+                tune=self.analysis_config.mcmc_tune,
+                chains=self.analysis_config.mcmc_chains,
+            )
+
+        posterior = trace.posterior
+
+        # Per-judge stats
+        bias_samples = posterior["bias"].values  # (chains, draws, n_judges)
+        noise_samples = posterior["noise"].values
+
+        n_chains, n_draws = bias_samples.shape[0], bias_samples.shape[1]
+        flat_bias = bias_samples.reshape(n_chains * n_draws, n_judges)
+        flat_noise = noise_samples.reshape(n_chains * n_draws, n_judges)
+
+        bias_hdi = az.hdi(trace, var_names=["bias"], hdi_prob=hdi_prob)
+        noise_hdi = az.hdi(trace, var_names=["noise"], hdi_prob=hdi_prob)
+
+        judges = {}
+        for j, name in enumerate(oracle_names):
+            judge_bias = flat_bias[:, j]
+            judge_noise = flat_noise[:, j]
+            raw_scores = per_judge_scores[name]
+
+            judges[name] = {
+                "bias_mean": float(judge_bias.mean()),
+                "bias_hdi": (
+                    float(bias_hdi["bias"].values[j, 0]),
+                    float(bias_hdi["bias"].values[j, 1]),
+                ),
+                "noise_mean": float(judge_noise.mean()),
+                "noise_hdi": (
+                    float(noise_hdi["noise"].values[j, 0]),
+                    float(noise_hdi["noise"].values[j, 1]),
+                ),
+                "n_evaluations": len(raw_scores),
+                "raw_score_mean": float(np.mean(raw_scores)),
+                "raw_score_std": float(np.std(raw_scores)),
+            }
+
+        # Consistency weights: 1/noise^2, normalized
+        # Use a floor to prevent near-zero noise from dominating
+        noise_values = [info["noise_mean"] for info in judges.values()]
+        non_tiny = [v for v in noise_values if v > 0.01]
+        noise_floor = max(min(non_tiny) if non_tiny else 0.05, 0.01)
+        weights = {}
+        for name, info in judges.items():
+            noise_val = max(info["noise_mean"], noise_floor)
+            weights[name] = 1.0 / (noise_val**2)
+        total_weight = sum(weights.values())
+        for name in judges:
+            judges[name]["consistency_weight"] = weights[name] / total_weight
+
+        result = {
+            "hdi_prob": hdi_prob,
+            "judges": judges,
+            "n_judges": n_judges,
+            "n_total_evaluations": len(scores_flat),
+        }
+
+        if expected_score is not None:
+            result["expected_score"] = expected_score
+        else:
+            # True quality stats (nuisance parameter, secondary output)
+            quality_samples = posterior["true_quality"].values.flatten()
+            quality_hdi = az.hdi(trace, var_names=["true_quality"], hdi_prob=hdi_prob)
+
+            result["true_quality_mean"] = float(quality_samples.mean())
+            result["true_quality_median"] = float(np.median(quality_samples))
+            result["true_quality_std"] = float(quality_samples.std())
+            result["hdi_lower"] = float(quality_hdi["true_quality"].values[0])
+            result["hdi_upper"] = float(quality_hdi["true_quality"].values[1])
+
+            # Bias-corrected weighted score
+            bc_num = sum(
+                judges[name]["consistency_weight"]
+                * (judges[name]["raw_score_mean"] - judges[name]["bias_mean"])
+                for name in oracle_names
+            )
+            result["bias_corrected_weighted_score"] = float(bc_num)
+
+        return result

--- a/src/metareason/cli/main.py
+++ b/src/metareason/cli/main.py
@@ -18,12 +18,13 @@ from rich.progress import (
 from rich.syntax import Syntax
 from rich.table import Table
 
+from ..analysis.agreement import compute_agreement_summary, extract_scores_by_oracle
 from ..analysis.analyzer import BayesianAnalyzer
 from ..config import SpecConfig
 from ..oracles.llm_judge import LLMJudge
 from ..oracles.oracle_base import EvaluationContext
 from ..pipeline import load_spec, runner
-from ..pipeline.loader import load_calibrate_spec
+from ..pipeline.loader import load_calibrate_multi_spec, load_calibrate_spec
 from ..pipeline.runner import SampleResult
 
 load_dotenv()
@@ -448,7 +449,12 @@ def validate(spec):
     is_flag=True,
     help="Generate HTML report after analysis",
 )
-def analyze(results_json, spec, oracle, report):
+@click.option(
+    "--agreement",
+    is_flag=True,
+    help="Compute inter-judge agreement metrics (requires multiple oracles)",
+)
+def analyze(results_json, spec, oracle, report, agreement):
     """Perform Bayesian analysis on previously saved evaluation results.
 
     This command loads evaluation results from a JSON file and runs Bayesian
@@ -502,16 +508,39 @@ def analyze(results_json, spec, oracle, report):
             if "parameter_effects" in pop_result:
                 display_parameter_effects(pop_result["parameter_effects"], oracle_name)
 
+        # Compute agreement metrics if requested
+        agreement_result = None
+        if agreement:
+            scores_by_oracle = extract_scores_by_oracle(results)
+            if len(scores_by_oracle) >= 2:
+                agreement_result = compute_agreement_summary(scores_by_oracle)
+                console.print("\n[bold magenta]Inter-Judge Agreement[/bold magenta]")
+                console.print(
+                    f"  Krippendorff's alpha: "
+                    f"{agreement_result['krippendorff_alpha']:.3f}"
+                )
+                if agreement_result["mean_pearson"] is not None:
+                    console.print(
+                        f"  Mean Pearson: {agreement_result['mean_pearson']:.3f}"
+                    )
+            else:
+                console.print(
+                    "[yellow]--agreement requires multiple oracles in results[/yellow]"
+                )
+
         # Save analysis results
         if analysis_results:
             console.print("\n[bold blue]Saving Analysis Results...[/bold blue]")
             for oracle_name, pop_result in analysis_results.items():
+                save_data = dict(pop_result)
+                if agreement_result:
+                    save_data["agreement"] = agreement_result
                 # Save population quality results as JSON
                 analysis_path = results_path.with_suffix("").with_suffix(
                     f".{oracle_name}_population_quality.json"
                 )
                 with open(analysis_path, "w") as f:
-                    json.dump(pop_result, f, indent=2)
+                    json.dump(save_data, f, indent=2)
                 console.print(
                     f"[green]✓ Population quality analysis for {oracle_name} saved to {analysis_path}[/green]"
                 )
@@ -590,43 +619,85 @@ def report(results_json, spec, output):
 
 
 def display_calibration_results(result: dict, oracle_name: str, calibrate_config):
-    """Display calibration-specific results with HDI and optional bias analysis."""
+    """Display judge calibration results focused on bias and consistency."""
     hdi_prob_pct = int(result["hdi_prob"] * 100)
 
     console.print(f"\n[bold magenta]Judge Calibration: {oracle_name}[/bold magenta]\n")
 
-    console.print(
-        f"[bold green]We are {hdi_prob_pct}% confident the true score "
-        f"is between {result['hdi_lower']:.2f} and {result['hdi_upper']:.2f}[/bold green]\n"
-    )
+    if "bias_mean" in result:
+        # With expected_score: report bias
+        expected = result["expected_score"]
+        bias_lo, bias_hi = result["bias_hdi"]
+        direction = "higher" if result["bias_mean"] > 0 else "lower"
+        console.print(
+            f"[bold green]This judge scores {result['bias_mean']:+.2f} vs ground truth "
+            f"({hdi_prob_pct}% CI: [{bias_lo:+.2f}, {bias_hi:+.2f}])[/bold green]\n"
+        )
 
-    console.print("[cyan]Score Statistics:[/cyan]")
-    console.print(f"  Mean: {result['population_mean']:.2f}")
-    console.print(f"  Median: {result['population_median']:.2f}")
-    console.print(f"  Std Dev: {result['population_std']:.2f}")
-    console.print(
-        f"  {hdi_prob_pct}% HDI: [{result['hdi_lower']:.2f}, {result['hdi_upper']:.2f}]"
-    )
+        console.print(
+            f"[cyan]Accuracy (bias) vs expected score of {expected:.1f}:[/cyan]"
+        )
+        console.print(
+            f"  Error: {result['bias_mean']:+.2f} "
+            f"(judge scores {direction} than ground truth)"
+        )
+        console.print(f"  {hdi_prob_pct}% CI: [{bias_lo:+.2f}, {bias_hi:+.2f}]")
+    else:
+        # Without expected_score: report estimated quality (secondary)
+        eq_lo, eq_hi = result["estimated_quality_hdi"]
+        console.print(
+            f"[bold green]Estimated quality: {result['estimated_quality_mean']:.2f} "
+            f"({hdi_prob_pct}% CI: [{eq_lo:.2f}, {eq_hi:.2f}])[/bold green]\n"
+        )
+        console.print("[dim]Bias cannot be estimated without an expected score.[/dim]")
 
-    noise_hdi_lower, noise_hdi_upper = result["oracle_noise_hdi"]
-    console.print("\n[cyan]Judge Consistency:[/cyan]")
+    noise_lo, noise_hi = result["noise_hdi"]
+    console.print("\n[cyan]Consistency (noise):[/cyan]")
     console.print(
-        f"  Measurement noise: {result['oracle_noise_mean']:.2f} "
-        f"({hdi_prob_pct}% HDI: [{noise_hdi_lower:.2f}, {noise_hdi_upper:.2f}])"
+        f"  Inconsistency: ±{result['noise_mean']:.2f} "
+        f"({hdi_prob_pct}% CI: [{noise_lo:.2f}, {noise_hi:.2f}])"
     )
     console.print(f"  Based on {result['n_samples']} repeated evaluations")
 
-    if calibrate_config.expected_score is not None:
-        expected = calibrate_config.expected_score
-        bias = result["population_mean"] - expected
-        within_hdi = result["hdi_lower"] <= expected <= result["hdi_upper"]
+    console.print("\n[cyan]Raw Scores:[/cyan]")
+    console.print(
+        f"  Mean: {result['raw_score_mean']:.2f}  "
+        f"Std: {result['raw_score_std']:.2f}"
+    )
 
-        console.print(f"\n[cyan]Accuracy (vs expected score of {expected:.1f}):[/cyan]")
-        direction = "higher" if bias > 0 else "lower"
-        console.print(
-            f"  Bias: {bias:+.2f} (judge scores {direction} than ground truth)"
-        )
-        console.print(f"  Expected score within HDI: {'Yes' if within_hdi else 'No'}")
+    # Verdict
+    console.print("\n[cyan]Verdict:[/cyan]")
+    noise_level = result["noise_mean"]
+    if "bias_mean" in result:
+        abs_bias = abs(result["bias_mean"])
+        if abs_bias < 0.2 and noise_level < 0.2:
+            console.print("  [green]Well-calibrated. Accurate and consistent.[/green]")
+        elif abs_bias >= 0.2 and noise_level < 0.2:
+            console.print(
+                f"  [yellow]Consistently {direction}. "
+                f"Usable if you adjust by ~{result['bias_mean']:+.2f}.[/yellow]"
+            )
+        elif abs_bias < 0.2 and noise_level >= 0.2:
+            console.print(
+                "  [yellow]Accurate on average but inconsistent. "
+                "Consider more repeats or lower temperature.[/yellow]"
+            )
+        else:
+            console.print(
+                f"  [red]Both biased ({result['bias_mean']:+.2f}) and noisy "
+                f"(±{noise_level:.2f}). Consider a different judge.[/red]"
+            )
+    else:
+        if noise_level < 0.2:
+            console.print(
+                "  [green]Consistent judge. "
+                "Add expected_score to measure accuracy.[/green]"
+            )
+        else:
+            console.print(
+                f"  [yellow]Noisy judge (±{noise_level:.2f}). "
+                "Consider lower temperature or a different model.[/yellow]"
+            )
 
 
 @metareason.command()
@@ -742,13 +813,15 @@ def calibrate(spec, output, report):
             console=console,
         ) as progress:
             analysis_task = progress.add_task("[cyan]MCMC sampling...", total=None)
-            pop_result = analyzer.estimate_population_quality(
-                oracle_name, hdi_prob=hdi_prob
+            cal_result = analyzer.estimate_judge_calibration(
+                oracle_name,
+                expected_score=calibrate_config.expected_score,
+                hdi_prob=hdi_prob,
             )
             progress.update(analysis_task, completed=True)
 
         # Display calibration results
-        display_calibration_results(pop_result, oracle_name, calibrate_config)
+        display_calibration_results(cal_result, oracle_name, calibrate_config)
 
         # Save results if output specified
         if output:
@@ -760,13 +833,10 @@ def calibrate(spec, output, report):
                 "oracle": oracle_name,
                 "repeats": calibrate_config.repeats,
                 "scores": scores,
-                "analysis": pop_result,
+                "analysis": cal_result,
             }
             if calibrate_config.expected_score is not None:
                 results_data["expected_score"] = calibrate_config.expected_score
-                results_data["bias"] = (
-                    pop_result["population_mean"] - calibrate_config.expected_score
-                )
 
             with open(output_path, "w") as f:
                 json.dump(results_data, f, indent=2)
@@ -776,7 +846,283 @@ def calibrate(spec, output, report):
         if report:
             from ..reporting import CalibrationReportGenerator
 
-            generator = CalibrationReportGenerator(calibrate_config, scores, pop_result)
+            generator = CalibrationReportGenerator(calibrate_config, scores, cal_result)
+
+            if output:
+                report_path = Path(output).with_suffix(".html")
+            else:
+                reports_dir = Path("reports")
+                reports_dir.mkdir(exist_ok=True)
+                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                spec_name = Path(spec).stem
+                report_path = reports_dir / f"{spec_name}_{timestamp}_report.html"
+
+            generator.generate_html(report_path)
+            console.print(f"[green]✓ HTML report saved to {report_path}[/green]")
+
+    except Exception as e:
+        console.print(f"[bold red]Error:[/bold red] {e}")
+        raise
+
+
+def display_multi_judge_results(multi_result, calibrate_config):
+    """Display multi-judge calibration results focused on per-judge assessment."""
+    hdi_prob_pct = int(multi_result["hdi_prob"] * 100)
+
+    console.print("\n[bold magenta]Multi-Judge Calibration Results[/bold magenta]\n")
+
+    # Per-judge verdicts first
+    has_expected = "expected_score" in multi_result
+    if has_expected:
+        expected = multi_result["expected_score"]
+        console.print(
+            f"[cyan]Per-Judge Assessment (vs expected score {expected:.1f}):[/cyan]\n"
+        )
+    else:
+        console.print("[cyan]Per-Judge Assessment:[/cyan]\n")
+
+    for name, info in multi_result["judges"].items():
+        bias_lo, bias_hi = info["bias_hdi"]
+        noise_lo, noise_hi = info["noise_hdi"]
+        abs_bias = abs(info["bias_mean"])
+        noise = info["noise_mean"]
+
+        if has_expected:
+            direction = "higher" if info["bias_mean"] > 0 else "lower"
+            console.print(
+                f"  [bold]{name}[/bold]: "
+                f"Accuracy (bias) {info['bias_mean']:+.2f} "
+                f"({hdi_prob_pct}% CI: [{bias_lo:+.2f}, {bias_hi:+.2f}]), "
+                f"Consistency (noise) ±{noise:.2f} "
+                f"({hdi_prob_pct}% CI: [{noise_lo:.2f}, {noise_hi:.2f}])"
+            )
+            # Verdict
+            if abs_bias < 0.2 and noise < 0.2:
+                console.print("    → [green]Well-calibrated[/green]")
+            elif abs_bias >= 0.2 and noise < 0.2:
+                console.print(
+                    f"    → [yellow]Consistently {direction} by "
+                    f"~{info['bias_mean']:+.2f}[/yellow]"
+                )
+            elif abs_bias < 0.2 and noise >= 0.2:
+                console.print(
+                    "    → [yellow]Accurate on average but inconsistent[/yellow]"
+                )
+            else:
+                console.print(
+                    f"    → [red]Biased ({info['bias_mean']:+.2f}) and noisy "
+                    f"(±{noise:.2f})[/red]"
+                )
+        else:
+            console.print(
+                f"  [bold]{name}[/bold]: "
+                f"Consistency (noise) ±{noise:.2f} "
+                f"({hdi_prob_pct}% CI: [{noise_lo:.2f}, {noise_hi:.2f}]), "
+                f"Relative accuracy (bias) {info['bias_mean']:+.2f}"
+            )
+
+    # Judge comparison table
+    table = Table(title="\nJudge Comparison")
+    table.add_column("Judge", style="cyan")
+    table.add_column("Accuracy (bias)", justify="right")
+    table.add_column("Consistency (noise)", justify="right")
+    table.add_column("Consistency Weight", justify="right")
+    table.add_column("Raw Mean", justify="right")
+    table.add_column("N", justify="right")
+
+    for name, info in multi_result["judges"].items():
+        table.add_row(
+            name,
+            f"{info['bias_mean']:+.3f}",
+            f"{info['noise_mean']:.3f}",
+            f"{info['consistency_weight']:.1%}",
+            f"{info['raw_score_mean']:.2f}",
+            str(info["n_evaluations"]),
+        )
+
+    console.print(table)
+
+    # Show consensus quality only when no expected_score (secondary info)
+    if not has_expected and "true_quality_mean" in multi_result:
+        console.print("\n[cyan]Estimated Quality (secondary):[/cyan]")
+        console.print(
+            f"  Mean: {multi_result['true_quality_mean']:.3f}  "
+            f"{hdi_prob_pct}% HDI: [{multi_result['hdi_lower']:.2f}, "
+            f"{multi_result['hdi_upper']:.2f}]"
+        )
+
+    console.print(
+        f"\n[dim]Based on {multi_result['n_judges']} judges, "
+        f"{multi_result['n_total_evaluations']} total evaluations[/dim]"
+    )
+
+
+@metareason.command(name="calibrate-multi")
+@click.argument("spec")
+@click.option("--output", "-o", help="Output file for results (JSON format)")
+@click.option("--report", is_flag=True, help="Generate HTML report")
+def calibrate_multi(spec, output, report):
+    """Calibrate multiple LLM judges and measure inter-judge agreement."""
+    try:
+        spec_path = Path(spec)
+        calibrate_config = load_calibrate_multi_spec(spec_path)
+
+        console.print(
+            f"[bold blue]Multi-judge calibration with spec:[/bold blue] {spec_path}"
+        )
+        console.print(
+            f"[dim]Running {calibrate_config.repeats} repeated evaluations "
+            f"across {len(calibrate_config.oracles)} judges...[/dim]\n"
+        )
+
+        # Initialize judges
+        judges = {}
+        for name, oracle_config in calibrate_config.oracles.items():
+            judges[name] = LLMJudge(oracle_config)
+
+        # Create evaluation context
+        eval_context = EvaluationContext(
+            prompt=calibrate_config.prompt,
+            response=calibrate_config.response,
+        )
+
+        # Run evaluations for each judge
+        per_judge_scores = {name: [] for name in judges}
+        per_judge_failures = {name: 0 for name in judges}
+
+        async def run_all_evaluations():
+            for name, judge in judges.items():
+                for _ in range(calibrate_config.repeats):
+                    try:
+                        result = await judge.evaluate(eval_context)
+                        per_judge_scores[name].append(result)
+                    except Exception as eval_err:
+                        per_judge_failures[name] += 1
+                        console.print(
+                            f"[yellow]{name} evaluation failed: {eval_err}[/yellow]"
+                        )
+
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            console=console,
+        ) as progress:
+            task = progress.add_task(
+                f"[cyan]Evaluating ({len(judges)} judges x "
+                f"{calibrate_config.repeats} repeats)...",
+                total=None,
+            )
+            asyncio.run(run_all_evaluations())
+            progress.update(task, completed=True)
+
+        # Check if any judges succeeded
+        active_judges = {
+            name: scores for name, scores in per_judge_scores.items() if scores
+        }
+        if len(active_judges) < 2:
+            console.print(
+                "[bold red]Error: Fewer than 2 judges produced results. "
+                "Cannot perform multi-judge analysis.[/bold red]"
+            )
+            return
+
+        # Display per-judge raw scores
+        for name, eval_results in active_judges.items():
+            scores = [r.score for r in eval_results]
+            failures = per_judge_failures[name]
+            total = len(scores) + failures
+            status = f"({len(scores)}/{total})" if failures else f"({len(scores)})"
+            console.print(
+                f"[dim]{name} {status}: "
+                f"{', '.join(f'{s:.1f}' for s in scores)}[/dim]"
+            )
+
+        # Build SampleResult objects — one per repeat
+        oracle_names = list(active_judges.keys())
+        max_evals = max(len(v) for v in active_judges.values())
+        sample_results = []
+
+        for i in range(max_evals):
+            evaluations = {}
+            for name in oracle_names:
+                if i < len(active_judges[name]):
+                    evaluations[name] = active_judges[name][i]
+            if evaluations:
+                sample_results.append(
+                    SampleResult(
+                        sample_params={},
+                        original_prompt=calibrate_config.prompt,
+                        final_response=calibrate_config.response,
+                        evaluations=evaluations,
+                    )
+                )
+
+        # Run hierarchical Bayesian analysis
+        console.print("\n[bold blue]Running Bayesian Analysis...[/bold blue]\n")
+
+        analysis_config = calibrate_config.analysis
+        analyzer = BayesianAnalyzer(sample_results, analysis_config=analysis_config)
+
+        hdi_prob = analysis_config.hdi_probability if analysis_config else 0.94
+
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            console=console,
+        ) as progress:
+            analysis_task = progress.add_task(
+                "[cyan]Hierarchical MCMC sampling...", total=None
+            )
+            multi_result = analyzer.estimate_multi_judge_quality(
+                oracle_names,
+                hdi_prob=hdi_prob,
+                expected_score=calibrate_config.expected_score,
+            )
+            progress.update(analysis_task, completed=True)
+
+        # Build scores dict for report
+        scores_by_oracle = {}
+        for name in oracle_names:
+            scores_by_oracle[name] = [r.score for r in active_judges[name]]
+
+        # Display results (no agreement metrics — those belong in `metareason run`)
+        display_multi_judge_results(multi_result, calibrate_config)
+
+        # Save JSON if output specified
+        if output:
+            output_path = Path(output)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+
+            results_data = {
+                "spec_id": calibrate_config.spec_id,
+                "oracles": oracle_names,
+                "repeats": calibrate_config.repeats,
+                "multi_judge_analysis": multi_result,
+                "per_judge_scores": {
+                    name: [r.score for r in results]
+                    for name, results in active_judges.items()
+                },
+            }
+            if calibrate_config.expected_score is not None:
+                results_data["expected_score"] = calibrate_config.expected_score
+
+            with open(output_path, "w") as f:
+                json.dump(results_data, f, indent=2)
+            console.print(f"\n[green]Results saved to {output_path}[/green]")
+
+        # Generate HTML report if requested
+        if report:
+            from ..reporting import MultiJudgeReportGenerator
+
+            generator = MultiJudgeReportGenerator(
+                calibrate_config,
+                scores_by_oracle,
+                multi_result,
+            )
 
             if output:
                 report_path = Path(output).with_suffix(".html")

--- a/src/metareason/config/__init__.py
+++ b/src/metareason/config/__init__.py
@@ -1,3 +1,15 @@
-from .models import AxisConfig, CalibrateConfig, OracleConfig, SpecConfig
+from .models import (
+    AxisConfig,
+    CalibrateConfig,
+    CalibrateMultiConfig,
+    OracleConfig,
+    SpecConfig,
+)
 
-__all__ = ["SpecConfig", "CalibrateConfig", "AxisConfig", "OracleConfig"]
+__all__ = [
+    "SpecConfig",
+    "CalibrateConfig",
+    "CalibrateMultiConfig",
+    "AxisConfig",
+    "OracleConfig",
+]

--- a/src/metareason/config/models.py
+++ b/src/metareason/config/models.py
@@ -218,6 +218,9 @@ class BayesianAnalysisConfig(BaseModel):
     # Prior for regression effect sizes
     prior_effect_sigma: float = Field(default=1.0, gt=0.0)
 
+    # Prior for judge bias in multi-judge models
+    prior_bias_sigma: float = Field(default=1.0, gt=0.0)
+
     # High-Density Interval (HDI) configuration
     hdi_probability: float = Field(default=0.94, gt=0.0, lt=1.0)
 
@@ -289,4 +292,21 @@ class CalibrateConfig(BaseModel):
     expected_score: Optional[float] = Field(default=None, ge=1.0, le=5.0)
     repeats: int = Field(default=30, ge=1)
     oracle: OracleConfig
+    analysis: Optional[BayesianAnalysisConfig] = None
+
+
+class CalibrateMultiConfig(BaseModel):
+    """Configuration for multi-judge calibration.
+
+    Measures agreement, bias, and reliability across multiple judges
+    by repeatedly evaluating a fixed prompt+response pair with each judge.
+    """
+
+    spec_id: str
+    type: Literal["calibrate_multi"] = "calibrate_multi"
+    prompt: str
+    response: str
+    expected_score: Optional[float] = Field(default=None, ge=1.0, le=5.0)
+    repeats: int = Field(default=30, ge=1)
+    oracles: Dict[str, OracleConfig] = Field(..., min_length=2)
     analysis: Optional[BayesianAnalysisConfig] = None

--- a/src/metareason/pipeline/__init__.py
+++ b/src/metareason/pipeline/__init__.py
@@ -1,4 +1,9 @@
-from .loader import load_calibrate_spec, load_spec
+from .loader import load_calibrate_multi_spec, load_calibrate_spec, load_spec
 from .renderer import TemplateRenderer
 
-__all__ = ["load_spec", "load_calibrate_spec", "TemplateRenderer"]
+__all__ = [
+    "load_spec",
+    "load_calibrate_spec",
+    "load_calibrate_multi_spec",
+    "TemplateRenderer",
+]

--- a/src/metareason/pipeline/loader.py
+++ b/src/metareason/pipeline/loader.py
@@ -3,7 +3,7 @@ from typing import Union
 
 import yaml
 
-from ..config import CalibrateConfig, SpecConfig
+from ..config import CalibrateConfig, CalibrateMultiConfig, SpecConfig
 
 
 def load_spec(file_path: Union[str, Path]) -> SpecConfig:
@@ -55,3 +55,25 @@ def load_calibrate_spec(file_path: Union[str, Path]) -> CalibrateConfig:
         data["response"] = _resolve_file_reference(data["response"], base_dir)
 
     return CalibrateConfig(**data)
+
+
+def load_calibrate_multi_spec(
+    file_path: Union[str, Path],
+) -> CalibrateMultiConfig:
+    """Load and validate a multi-judge calibration YAML specification file.
+
+    Resolves 'file:' prefixes in prompt and response fields to load
+    content from external files (paths relative to the spec file).
+    """
+    path = Path(file_path)
+    base_dir = path.parent
+
+    with open(path, "r") as f:
+        data = yaml.safe_load(f)
+
+    if "prompt" in data:
+        data["prompt"] = _resolve_file_reference(data["prompt"], base_dir)
+    if "response" in data:
+        data["response"] = _resolve_file_reference(data["response"], base_dir)
+
+    return CalibrateMultiConfig(**data)

--- a/src/metareason/reporting/__init__.py
+++ b/src/metareason/reporting/__init__.py
@@ -1,4 +1,5 @@
 from .calibration_report import CalibrationReportGenerator
+from .multi_judge_report import MultiJudgeReportGenerator
 from .report_generator import ReportGenerator
 from .visualizations import (
     figure_to_base64,
@@ -11,6 +12,7 @@ from .visualizations import (
 
 __all__ = [
     "CalibrationReportGenerator",
+    "MultiJudgeReportGenerator",
     "ReportGenerator",
     "figure_to_base64",
     "plot_convergence_diagnostics",

--- a/src/metareason/reporting/calibration_report.py
+++ b/src/metareason/reporting/calibration_report.py
@@ -12,12 +12,12 @@ from metareason.reporting.report_generator import _load_vendor_asset
 
 
 class CalibrationReportGenerator:
-    """Generates self-contained HTML reports from calibration results.
+    """Generates self-contained HTML reports from judge calibration results.
 
     Args:
         config: CalibrateConfig used for the calibration.
         scores: List of raw scores from repeated evaluations.
-        analysis_result: Dict from BayesianAnalyzer.estimate_population_quality().
+        analysis_result: Dict from BayesianAnalyzer.estimate_judge_calibration().
     """
 
     def __init__(
@@ -52,16 +52,37 @@ class CalibrationReportGenerator:
         if self.config.analysis:
             hdi_prob = self.config.analysis.hdi_probability
 
-        has_expected = self.config.expected_score is not None
-        bias = None
-        within_hdi = None
+        has_expected = "expected_score" in self.analysis
+
+        # Build verdict
+        noise = self.analysis["noise_mean"]
         if has_expected:
-            bias = self.analysis["population_mean"] - self.config.expected_score
-            within_hdi = (
-                self.analysis["hdi_lower"]
-                <= self.config.expected_score
-                <= self.analysis["hdi_upper"]
-            )
+            abs_bias = abs(self.analysis["bias_mean"])
+            direction = "higher" if self.analysis["bias_mean"] > 0 else "lower"
+            if abs_bias < 0.2 and noise < 0.2:
+                verdict = "Well-calibrated. Accurate and consistent."
+                verdict_class = "good"
+            elif abs_bias >= 0.2 and noise < 0.2:
+                verdict = (
+                    f"Consistently {direction}. "
+                    f"Usable if you adjust by ~{self.analysis['bias_mean']:+.2f}."
+                )
+                verdict_class = "warn"
+            elif abs_bias < 0.2 and noise >= 0.2:
+                verdict = (
+                    "Accurate on average but inconsistent. "
+                    "Consider more repeats or lower temperature."
+                )
+                verdict_class = "warn"
+            else:
+                verdict = (
+                    f"Both biased ({self.analysis['bias_mean']:+.2f}) and noisy "
+                    f"(±{noise:.1f}). Consider a different judge."
+                )
+                verdict_class = "bad"
+        else:
+            verdict = None
+            verdict_class = None
 
         return {
             "title": f"MetaReason Calibration Report: {self.config.spec_id}",
@@ -78,29 +99,33 @@ class CalibrationReportGenerator:
             "prompt": self.config.prompt,
             "response": self.config.response,
             "has_expected": has_expected,
-            "expected_score": self.config.expected_score,
-            "bias": bias,
-            "within_hdi": within_hdi,
+            "expected_score": self.analysis.get("expected_score"),
+            "verdict": verdict,
+            "verdict_class": verdict_class,
         }
 
     def _generate_chart_data(self) -> dict:
         """Generate JSON-serializable chart data for Chart.js."""
         chart_data = {}
         scores = np.array(self.scores)
+        has_expected = "expected_score" in self.analysis
 
-        # Posterior KDE
-        mean = self.analysis["population_mean"]
-        hdi_width = self.analysis["hdi_upper"] - self.analysis["hdi_lower"]
-        std_approx = hdi_width / 3.3
-        posterior_samples = np.random.normal(mean, std_approx, 4000)
+        if has_expected:
+            # Bias posterior KDE
+            bias_mean = self.analysis["bias_mean"]
+            bias_lo, bias_hi = self.analysis["bias_hdi"]
+            bias_width = bias_hi - bias_lo
+            bias_std = max(bias_width / 3.3, 0.01)
+            bias_samples = np.random.normal(bias_mean, bias_std, 4000)
 
-        kde = gaussian_kde(posterior_samples)
-        x = np.linspace(
-            posterior_samples.min() - 0.5, posterior_samples.max() + 0.5, 80
-        )
-        y = kde(x)
-        chart_data["posterior_x"] = [round(float(v), 4) for v in x]
-        chart_data["posterior_y"] = [round(float(v), 4) for v in y]
+            kde = gaussian_kde(bias_samples)
+            x = np.linspace(bias_samples.min() - 0.5, bias_samples.max() + 0.5, 80)
+            y = kde(x)
+            chart_data["bias_x"] = [round(float(v), 4) for v in x]
+            chart_data["bias_y"] = [round(float(v), 4) for v in y]
+            chart_data["bias_mean"] = round(float(bias_mean), 4)
+            chart_data["bias_hdi_lower"] = round(float(bias_lo), 4)
+            chart_data["bias_hdi_upper"] = round(float(bias_hi), 4)
 
         # Score histogram
         bins = [0.5, 1.5, 2.5, 3.5, 4.5, 5.5]
@@ -110,9 +135,9 @@ class CalibrationReportGenerator:
         chart_data["score_mean"] = round(float(np.mean(scores)), 3)
 
         # Noise KDE
-        noise_mean = self.analysis["oracle_noise_mean"]
-        noise_hdi = self.analysis["oracle_noise_hdi"]
-        noise_width = noise_hdi[1] - noise_hdi[0]
+        noise_mean = self.analysis["noise_mean"]
+        noise_lo, noise_hi = self.analysis["noise_hdi"]
+        noise_width = noise_hi - noise_lo
         noise_std = max(noise_width / 3.3, 0.01)
         noise_samples = np.abs(np.random.normal(noise_mean, noise_std, 4000))
 
@@ -125,19 +150,11 @@ class CalibrationReportGenerator:
         ny = noise_kde(nx)
         chart_data["noise_x"] = [round(float(v), 4) for v in nx]
         chart_data["noise_y"] = [round(float(v), 4) for v in ny]
-
-        # Analysis values for chart annotations
-        chart_data["hdi_lower"] = round(float(self.analysis["hdi_lower"]), 4)
-        chart_data["hdi_upper"] = round(float(self.analysis["hdi_upper"]), 4)
-        chart_data["population_mean"] = round(
-            float(self.analysis["population_mean"]), 4
-        )
-        chart_data["population_median"] = round(
-            float(self.analysis["population_median"]), 4
-        )
         chart_data["noise_mean"] = round(float(noise_mean), 4)
-        chart_data["noise_hdi_lower"] = round(float(noise_hdi[0]), 4)
-        chart_data["noise_hdi_upper"] = round(float(noise_hdi[1]), 4)
+        chart_data["noise_hdi_lower"] = round(float(noise_lo), 4)
+        chart_data["noise_hdi_upper"] = round(float(noise_hi), 4)
+
+        chart_data["has_expected"] = has_expected
 
         return chart_data
 

--- a/src/metareason/reporting/multi_judge_report.py
+++ b/src/metareason/reporting/multi_judge_report.py
@@ -1,0 +1,184 @@
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+from jinja2 import Environment, PackageLoader
+from scipy.stats import gaussian_kde
+
+from metareason.config.models import CalibrateMultiConfig
+from metareason.reporting.report_generator import _load_vendor_asset
+
+
+class MultiJudgeReportGenerator:
+    """Generates self-contained HTML reports from multi-judge calibration results.
+
+    Args:
+        config: CalibrateMultiConfig used for the calibration.
+        scores_by_oracle: Dict mapping oracle name to list of scores.
+        multi_judge_result: Dict from BayesianAnalyzer.estimate_multi_judge_quality().
+    """
+
+    def __init__(
+        self,
+        config: CalibrateMultiConfig,
+        scores_by_oracle: Dict[str, List[float]],
+        multi_judge_result: dict,
+    ):
+        self.config = config
+        self.scores_by_oracle = scores_by_oracle
+        self.multi_judge = multi_judge_result
+        self.env = Environment(  # nosec B701 - autoescape off for JSON embedding
+            loader=PackageLoader("metareason.reporting", "templates"),
+            autoescape=False,
+        )
+        self.env.filters["tojson"] = json.dumps
+
+    def generate_html(self, output_path: Path) -> Path:
+        """Generate HTML report and save to output_path."""
+        chart_data = self._generate_chart_data()
+        data = self._collect_data()
+        html = self._render_template(data, chart_data)
+
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(html)
+        return output_path
+
+    def _collect_data(self) -> dict:
+        """Extract data for template context."""
+        hdi_prob = 0.94
+        if self.config.analysis:
+            hdi_prob = self.config.analysis.hdi_probability
+
+        has_expected = "expected_score" in self.multi_judge
+
+        # Per-judge verdicts
+        judge_verdicts = {}
+        for name, info in self.multi_judge["judges"].items():
+            abs_bias = abs(info["bias_mean"])
+            noise = info["noise_mean"]
+            direction = "higher" if info["bias_mean"] > 0 else "lower"
+
+            if has_expected:
+                if abs_bias < 0.2 and noise < 0.2:
+                    verdict = "Well-calibrated"
+                    verdict_class = "good"
+                elif abs_bias >= 0.2 and noise < 0.2:
+                    verdict = f"Consistently {direction} by ~{info['bias_mean']:+.2f}"
+                    verdict_class = "warn"
+                elif abs_bias < 0.2 and noise >= 0.2:
+                    verdict = "Accurate on average but inconsistent"
+                    verdict_class = "warn"
+                else:
+                    verdict = f"Biased ({info['bias_mean']:+.2f}) and noisy"
+                    verdict_class = "bad"
+            else:
+                if noise < 0.2:
+                    verdict = "Consistent"
+                    verdict_class = "good"
+                else:
+                    verdict = f"Inconsistent (±{noise:.2f})"
+                    verdict_class = "warn"
+
+            judge_verdicts[name] = {
+                "verdict": verdict,
+                "verdict_class": verdict_class,
+            }
+
+        # Noise threshold recommendation
+        recommendations = []
+        for name, info in self.multi_judge["judges"].items():
+            if info["noise_mean"] > 1.0:
+                recommendations.append(
+                    f"Consider dropping {name} (noise={info['noise_mean']:.2f})"
+                )
+
+        return {
+            "title": f"MetaReason Multi-Judge Report: {self.config.spec_id}",
+            "spec_id": self.config.spec_id,
+            "repeats": self.config.repeats,
+            "n_judges": self.multi_judge["n_judges"],
+            "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "hdi_pct": int(hdi_prob * 100),
+            "multi_judge": self.multi_judge,
+            "has_expected": has_expected,
+            "expected_score": self.multi_judge.get("expected_score"),
+            "judge_verdicts": judge_verdicts,
+            "recommendations": recommendations,
+            "prompt": self.config.prompt,
+            "response": self.config.response,
+        }
+
+    def _generate_chart_data(self) -> dict:
+        """Generate JSON-serializable chart data for Chart.js."""
+        chart_data = {}
+        has_expected = "expected_score" in self.multi_judge
+
+        # Per-judge score histograms
+        judge_names = list(self.scores_by_oracle.keys())
+        chart_data["judge_names"] = judge_names
+        chart_data["judge_histograms"] = {}
+        bins = [0.5, 1.5, 2.5, 3.5, 4.5, 5.5]
+        for name, scores in self.scores_by_oracle.items():
+            counts, _ = np.histogram(scores, bins=bins)
+            chart_data["judge_histograms"][name] = [int(c) for c in counts]
+
+        chart_data["histogram_labels"] = ["1", "2", "3", "4", "5"]
+
+        # Per-judge bias posterior KDEs
+        chart_data["bias_posteriors"] = {}
+        for name, info in self.multi_judge["judges"].items():
+            bias_mean = info["bias_mean"]
+            bias_lo, bias_hi = info["bias_hdi"]
+            bias_width = bias_hi - bias_lo
+            bias_std = max(bias_width / 3.3, 0.01)
+            samples = np.random.normal(bias_mean, bias_std, 4000)
+
+            kde = gaussian_kde(samples)
+            x = np.linspace(samples.min() - 0.3, samples.max() + 0.3, 60)
+            y = kde(x)
+            chart_data["bias_posteriors"][name] = {
+                "x": [round(float(v), 4) for v in x],
+                "y": [round(float(v), 4) for v in y],
+                "mean": round(float(bias_mean), 4),
+                "hdi_lower": round(float(bias_lo), 4),
+                "hdi_upper": round(float(bias_hi), 4),
+            }
+
+        # Per-judge noise posterior KDEs
+        chart_data["noise_posteriors"] = {}
+        for name, info in self.multi_judge["judges"].items():
+            noise_mean = info["noise_mean"]
+            noise_lo, noise_hi = info["noise_hdi"]
+            noise_width = noise_hi - noise_lo
+            noise_std = max(noise_width / 3.3, 0.01)
+            samples = np.abs(np.random.normal(noise_mean, noise_std, 4000))
+
+            kde = gaussian_kde(samples)
+            x = np.linspace(max(0, samples.min() - 0.1), samples.max() + 0.1, 60)
+            y = kde(x)
+            chart_data["noise_posteriors"][name] = {
+                "x": [round(float(v), 4) for v in x],
+                "y": [round(float(v), 4) for v in y],
+                "mean": round(float(noise_mean), 4),
+                "hdi_lower": round(float(noise_lo), 4),
+                "hdi_upper": round(float(noise_hi), 4),
+            }
+
+        chart_data["has_expected"] = has_expected
+
+        return chart_data
+
+    def _render_template(self, data: dict, chart_data: dict) -> str:
+        """Render the Jinja2 template with data and chart data."""
+        template = self.env.get_template("multi_judge_report.html.j2")
+        return template.render(
+            chart_data=chart_data,
+            chartjs_source=_load_vendor_asset("chart.umd.min.js"),
+            chartjs_annotation_source=_load_vendor_asset(
+                "chartjs-plugin-annotation.min.js"
+            ),
+            **data,
+        )

--- a/src/metareason/reporting/templates/calibration_report.html.j2
+++ b/src/metareason/reporting/templates/calibration_report.html.j2
@@ -13,19 +13,14 @@
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #f8fafc; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
         .card { background: white; border-radius: 12px; box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1); border: 1px solid #e2e8f0; }
-        .code-pill { font-family: 'Monaco', 'Consolas', monospace; font-size: 0.85em; background-color: #f1f5f9; padding: 2px 6px; border-radius: 4px; color: #475569; }
 
         /* Layout */
         .flex { display: flex; }
         .flex-col { flex-direction: column; }
-        .flex-grow { flex-grow: 1; }
         .items-center { align-items: center; }
         .items-end { align-items: flex-end; }
         .justify-between { justify-content: space-between; }
-        .justify-center { justify-content: center; }
-        .gap-2 { gap: 0.5rem; }
         .gap-3 { gap: 0.75rem; }
-        .gap-4 { gap: 1rem; }
         .gap-6 { gap: 1.5rem; }
         .grid { display: grid; }
         .grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
@@ -40,18 +35,14 @@
         .p-5 { padding: 1.25rem; }
         .p-6 { padding: 1.5rem; }
         .p-8 { padding: 2rem; }
-        .px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
         .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
         .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-        .px-4 { padding-left: 1rem; padding-right: 1rem; }
         .px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
-        .py-0\.5 { padding-top: 0.125rem; padding-bottom: 0.125rem; }
         .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
         .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
         .py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
         .py-4 { padding-top: 1rem; padding-bottom: 1rem; }
         .mb-1 { margin-bottom: 0.25rem; }
-        .mb-2 { margin-bottom: 0.5rem; }
         .mb-3 { margin-bottom: 0.75rem; }
         .mb-4 { margin-bottom: 1rem; }
         .mb-8 { margin-bottom: 2rem; }
@@ -73,11 +64,9 @@
         .font-medium { font-weight: 500; }
         .font-mono { font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
         .uppercase { text-transform: uppercase; }
-        .tracking-wider { letter-spacing: 0.05em; }
         .tracking-wide { letter-spacing: 0.025em; }
         .text-left { text-align: left; }
         .text-center { text-align: center; }
-        .antialiased { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
         .whitespace-pre-wrap { white-space: pre-wrap; }
         pre { font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
         .max-h-24 { max-height: 6rem; }
@@ -93,21 +82,16 @@
         .text-slate-900 { color: #0f172a; }
         .text-indigo-600 { color: #4f46e5; }
         .text-indigo-700 { color: #4338ca; }
-        .text-indigo-100 { color: #e0e7ff; }
         .text-blue-600 { color: #2563eb; }
         .text-green-600 { color: #16a34a; }
         .text-amber-600 { color: #d97706; }
+        .text-red-600 { color: #dc2626; }
         .bg-white { background-color: #ffffff; }
         .bg-slate-50 { background-color: #f8fafc; }
         .bg-slate-900 { background-color: #0f172a; }
         .bg-blue-50 { background-color: #eff6ff; }
         .bg-slate-100 { background-color: #f1f5f9; }
         .bg-indigo-50 { background-color: #eef2ff; }
-        .bg-white\/20 { background-color: rgba(255, 255, 255, 0.2); }
-        .bg-white\/10 { background-color: rgba(255, 255, 255, 0.1); }
-        .bg-gradient-to-r { background-image: linear-gradient(to right, var(--tw-gradient-from), var(--tw-gradient-to)); }
-        .from-indigo-600 { --tw-gradient-from: #4f46e5; --tw-gradient-to: #4f46e5; }
-        .to-blue-500 { --tw-gradient-to: #3b82f6; }
 
         /* Borders */
         .border { border-width: 1px; border-style: solid; border-color: #e2e8f0; }
@@ -120,6 +104,7 @@
         .border-l-slate-400 { border-left-color: #94a3b8; }
         .border-l-green-500 { border-left-color: #22c55e; }
         .border-l-amber-500 { border-left-color: #f59e0b; }
+        .border-l-red-500 { border-left-color: #ef4444; }
         .rounded { border-radius: 0.25rem; }
         .rounded-lg { border-radius: 0.5rem; }
         .rounded-xl { border-radius: 0.75rem; }
@@ -135,63 +120,80 @@
 
         /* Effects */
         .shadow-lg { box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1); }
-        .opacity-90 { opacity: 0.9; }
-        .transition { transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
+        .transition { transition: all 150ms ease; }
 
         /* Table */
         .divide-y > * + * { border-top-width: 1px; border-top-style: solid; }
         .divide-slate-100 > * + * { border-top-color: #f1f5f9; }
 
-        /* Hover */
         .hover\:bg-slate-700:hover { background-color: #334155; }
         .hover\:bg-slate-50:hover { background-color: #f8fafc; }
+
+        /* Help button styles */
+        .help-btn {
+            display: inline-flex; align-items: center; justify-content: center;
+            width: 20px; height: 20px; border-radius: 50%;
+            background: #e2e8f0; color: #64748b; border: none;
+            font-size: 12px; font-weight: 700; cursor: pointer;
+            margin-left: 6px; vertical-align: middle; line-height: 1;
+            transition: all 150ms ease; flex-shrink: 0;
+        }
+        .help-btn:hover { background: #4f46e5; color: white; }
+        .help-btn.active { background: #4f46e5; color: white; }
+        .help-text {
+            display: none; margin-top: 0.75rem; padding: 0.75rem 1rem;
+            background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px;
+            font-size: 0.8125rem; line-height: 1.6; color: #475569;
+            animation: helpFadeIn 150ms ease;
+        }
+        .help-text.open { display: block; }
+        .help-text strong { color: #1e293b; }
+        @keyframes helpFadeIn {
+            from { opacity: 0; transform: translateY(-4px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
 
         /* Responsive */
         @media (min-width: 768px) {
             .md\:flex-row { flex-direction: row; }
             .md\:items-center { align-items: center; }
             .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-            .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
             .md\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
             .md\:p-8 { padding: 2rem; }
-            .md\:p-10 { padding: 2.5rem; }
             .md\:text-2xl { font-size: 1.5rem; line-height: 2rem; }
         }
         @media (min-width: 1024px) {
             .lg\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
         }
-
-        /* Print */
         @media print {
             body { background-color: white; }
             .card { box-shadow: none; border: 1px solid #ddd; break-inside: avoid; margin-bottom: 20px; }
             .no-print { display: none; }
+            .help-btn { display: none; }
+            .help-text { display: none !important; }
         }
     </style>
 </head>
-<body class="text-slate-800 antialiased p-6 md:p-10 max-w-7xl mx-auto">
+<body class="text-slate-800 p-6 md:p-8 max-w-7xl mx-auto">
 
     <!-- Header -->
-    <header class="flex flex-col md:flex-row md:items-center justify-between mb-8 gap-4">
+    <header class="flex flex-col md:flex-row md:items-center justify-between mb-8 gap-3">
         <div>
-            <div class="text-xs font-bold tracking-wider text-indigo-600 uppercase mb-1">MetaReason Calibration Report</div>
+            <div class="text-xs font-bold tracking-wide text-indigo-600 uppercase mb-1">MetaReason Judge Calibration Report</div>
             <h1 class="text-3xl font-bold text-slate-900">{{ spec_id }}</h1>
             <p class="text-slate-500 text-sm mt-1">Generated: {{ timestamp }}</p>
         </div>
         <div class="flex gap-3">
-            <div class="flex flex-col items-end px-4 py-2 bg-white rounded-lg border border-slate-200">
+            <div class="flex flex-col items-end px-3 py-2 bg-white rounded-lg border border-slate-200">
                 <span class="text-xs text-slate-500 uppercase font-semibold">Repeats</span>
                 <span class="font-bold text-lg">{{ repeats }}</span>
             </div>
-            <button onclick="window.print()" class="no-print px-4 py-2 bg-slate-900 text-white rounded-lg hover:bg-slate-700 transition font-medium text-sm">
-                Print Report
-            </button>
+            <button onclick="window.print()" class="no-print px-3 py-2 bg-slate-900 text-white rounded-lg hover:bg-slate-700 transition font-medium text-sm">Print</button>
         </div>
     </header>
 
     <!-- Configuration Grid -->
     <section class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-        <!-- Oracle Config -->
         <div class="card p-6">
             <h3 class="text-sm font-semibold text-slate-400 uppercase tracking-wide mb-4 flex items-center gap-2">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
@@ -200,18 +202,10 @@
             <div class="overflow-x-auto">
                 <table class="w-full text-sm text-left">
                     <thead class="text-xs text-slate-500 bg-slate-50 uppercase border-b">
-                        <tr>
-                            <th class="px-3 py-2">Model</th>
-                            <th class="px-3 py-2">Adapter</th>
-                            <th class="px-3 py-2">Temperature</th>
-                        </tr>
+                        <tr><th class="px-3 py-2">Model</th><th class="px-3 py-2">Adapter</th><th class="px-3 py-2">Temperature</th></tr>
                     </thead>
                     <tbody>
-                        <tr>
-                            <td class="px-3 py-3 font-medium text-indigo-700">{{ oracle_model }}</td>
-                            <td class="px-3 py-3">{{ oracle_adapter }}</td>
-                            <td class="px-3 py-3">{{ oracle_temperature }}</td>
-                        </tr>
+                        <tr><td class="px-3 py-3 font-medium text-indigo-700">{{ oracle_model }}</td><td class="px-3 py-3">{{ oracle_adapter }}</td><td class="px-3 py-3">{{ oracle_temperature }}</td></tr>
                     </tbody>
                 </table>
             </div>
@@ -222,8 +216,6 @@
             </div>
             {% endif %}
         </div>
-
-        <!-- Prompt / Response -->
         <div class="card p-6">
             <h3 class="text-sm font-semibold text-slate-400 uppercase tracking-wide mb-4 flex items-center gap-2">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"></path></svg>
@@ -240,112 +232,150 @@
         </div>
     </section>
 
-    <!-- Confidence Assessment -->
-    <div class="bg-gradient-to-r from-indigo-600 to-blue-500 rounded-xl p-6 md:p-8 text-white shadow-lg mb-8">
-        <h2 class="text-xl md:text-2xl font-bold mb-2">Confidence Assessment</h2>
-        <p class="text-indigo-100 text-lg opacity-90">
-            We are <span class="font-bold text-white bg-white/20 px-1 rounded">{{ hdi_pct }}% confident</span>
-            the true score is between
-            <strong>{{ analysis.hdi_lower | round(2) }}</strong> and <strong>{{ analysis.hdi_upper | round(2) }}</strong>.
+    <!-- Judge Assessment (Hero) -->
+    {% if has_expected %}
+    <div class="card p-6 md:p-8 shadow-lg mb-8 border-l-4 {% if verdict_class == 'good' %}border-l-green-500{% elif verdict_class == 'warn' %}border-l-amber-500{% else %}border-l-red-500{% endif %}">
+        <div class="flex items-center mb-4">
+            <h2 class="text-xl md:text-2xl font-bold">Judge Assessment</h2>
+            <button class="help-btn no-print" onclick="toggleHelp('help-assessment')">?</button>
+        </div>
+        <div class="help-text" id="help-assessment">
+            The main finding. The judge was asked to score the same content {{ repeats }} times with a known correct score of {{ expected_score }}. This section summarizes how <strong>accurate</strong> (close to the correct answer) and <strong>consistent</strong> (repeatable) the judge is.
+            <br><br>
+            The <strong>{{ hdi_pct }}% confidence interval</strong> comes from Bayesian analysis &mdash; it's the range we're {{ hdi_pct }}% sure the true value lies within.
+        </div>
+        <p class="text-lg">
+            This judge scores <span class="font-bold">{{ "%+.2f"|format(analysis.bias_mean) }}</span> vs ground truth on average.
+            With <span class="font-bold">{{ hdi_pct }}%</span> confidence, the error is between
+            <strong>{{ "%+.2f"|format(analysis.bias_hdi[0]) }}</strong> and <strong>{{ "%+.2f"|format(analysis.bias_hdi[1]) }}</strong>.
         </p>
+        {% if verdict %}
+        <p class="mt-4 text-sm font-semibold {% if verdict_class == 'good' %}text-green-600{% elif verdict_class == 'warn' %}text-amber-600{% else %}text-red-600{% endif %}">{{ verdict }}</p>
+        {% endif %}
     </div>
+    {% else %}
+    <div class="card p-6 md:p-8 shadow-lg mb-8 border-l-4 border-l-slate-400">
+        <div class="flex items-center mb-4">
+            <h2 class="text-xl md:text-2xl font-bold">Judge Assessment</h2>
+            <button class="help-btn no-print" onclick="toggleHelp('help-assessment')">?</button>
+        </div>
+        <div class="help-text" id="help-assessment">
+            The judge was asked to score the same content {{ repeats }} times. Without a known correct score (<code>expected_score</code>), we can only measure <strong>consistency</strong> (how much scores scatter), not <strong>accuracy</strong> (whether it gets the right answer). Add <code>expected_score</code> to your spec to enable accuracy measurement.
+        </div>
+        <p class="text-lg">
+            This judge varies by <span class="font-bold">&plusmn;{{ "%.2f"|format(analysis.noise_mean) }}</span> points across repeated evaluations.
+        </p>
+        <p class="text-sm text-slate-500 mt-1">Accuracy cannot be estimated without an expected score.</p>
+    </div>
+    {% endif %}
 
     <!-- Metrics Row -->
-    <section class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+    <section class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-8">
+        {% if has_expected %}
         <div class="card p-5 border-l-4 border-l-blue-500">
-            <div class="text-slate-500 text-xs uppercase font-semibold mb-1">Mean Score</div>
-            <div class="text-3xl font-bold text-slate-800">{{ analysis.population_mean | round(3) }}</div>
+            <div class="flex items-center">
+                <div class="text-slate-500 text-xs uppercase font-semibold mb-1">Accuracy (bias)</div>
+                <button class="help-btn no-print" onclick="toggleHelp('help-m-bias')" style="margin-bottom:4px;">?</button>
+            </div>
+            <div class="help-text" id="help-m-bias">How far the judge's average score is from the known correct score of {{ expected_score }}. Positive = scores too high. Negative = scores too low. Zero = perfectly accurate.</div>
+            <div class="text-3xl font-bold text-slate-800">{{ "%+.2f"|format(analysis.bias_mean) }}</div>
+            <div class="text-xs text-slate-400 mt-1">vs expected {{ expected_score }}</div>
+        </div>
+        <div class="card p-5 border-l-4 border-l-indigo-500">
+            <div class="flex items-center">
+                <div class="text-slate-500 text-xs uppercase font-semibold mb-1">{{ hdi_pct }}% Accuracy CI</div>
+                <button class="help-btn no-print" onclick="toggleHelp('help-m-bci')" style="margin-bottom:4px;">?</button>
+            </div>
+            <div class="help-text" id="help-m-bci">The credible interval for the accuracy estimate. We are {{ hdi_pct }}% confident the judge's true systematic error lies in this range. If the range includes zero, the judge <em>might</em> be perfectly accurate.</div>
+            <div class="text-2xl font-bold text-slate-800">{{ "%+.2f"|format(analysis.bias_hdi[0]) }} &ndash; {{ "%+.2f"|format(analysis.bias_hdi[1]) }}</div>
+        </div>
+        {% else %}
+        <div class="card p-5 border-l-4 border-l-blue-500">
+            <div class="text-slate-500 text-xs uppercase font-semibold mb-1">Raw Mean</div>
+            <div class="text-3xl font-bold text-slate-800">{{ "%.2f"|format(analysis.raw_score_mean) }}</div>
             <div class="text-xs text-slate-400 mt-1">Across {{ repeats }} repeats</div>
         </div>
         <div class="card p-5 border-l-4 border-l-indigo-500">
-            <div class="text-slate-500 text-xs uppercase font-semibold mb-1">Median Score</div>
-            <div class="text-3xl font-bold text-slate-800">{{ analysis.population_median | round(3) }}</div>
-            <div class="text-xs text-slate-400 mt-1">Across {{ repeats }} repeats</div>
+            <div class="text-slate-500 text-xs uppercase font-semibold mb-1">Estimated Quality</div>
+            <div class="text-2xl font-bold text-slate-800">{{ "%.2f"|format(analysis.estimated_quality_mean) }}</div>
+            <div class="text-xs text-slate-400 mt-1">Bayesian estimate</div>
         </div>
+        {% endif %}
         <div class="card p-5 border-l-4 border-l-purple-500">
-            <div class="text-slate-500 text-xs uppercase font-semibold mb-1">{{ hdi_pct }}% HDI</div>
-            <div class="text-2xl font-bold text-slate-800">{{ analysis.hdi_lower | round(2) }} &ndash; {{ analysis.hdi_upper | round(2) }}</div>
-            <div class="text-xs text-slate-400 mt-1">Highest Density Interval</div>
+            <div class="flex items-center">
+                <div class="text-slate-500 text-xs uppercase font-semibold mb-1">Consistency (noise)</div>
+                <button class="help-btn no-print" onclick="toggleHelp('help-m-noise')" style="margin-bottom:4px;">?</button>
+            </div>
+            <div class="help-text" id="help-m-noise">How much the judge's scores scatter when evaluating the same content repeatedly. A value of 0.3 means scores typically wander &plusmn;0.3 points around the average. Lower = more predictable.</div>
+            <div class="text-3xl font-bold text-slate-800">&plusmn;{{ "%.2f"|format(analysis.noise_mean) }}</div>
         </div>
         <div class="card p-5 border-l-4 border-l-slate-400 bg-slate-50">
-            <div class="text-slate-500 text-xs uppercase font-semibold mb-1">Judge Noise</div>
-            <div class="text-3xl font-bold text-slate-800">{{ analysis.oracle_noise_mean | round(2) }}</div>
+            <div class="flex items-center">
+                <div class="text-slate-500 text-xs uppercase font-semibold mb-1">{{ hdi_pct }}% Consistency CI</div>
+                <button class="help-btn no-print" onclick="toggleHelp('help-m-nci')" style="margin-bottom:4px;">?</button>
+            </div>
+            <div class="help-text" id="help-m-nci">The credible interval for the consistency estimate. We are {{ hdi_pct }}% confident the judge's true inconsistency level lies in this range.</div>
+            <div class="text-2xl font-bold text-slate-800">{{ "%.2f"|format(analysis.noise_hdi[0]) }} &ndash; {{ "%.2f"|format(analysis.noise_hdi[1]) }}</div>
             <div class="text-xs text-slate-400 mt-1">{{ oracle_model }}</div>
         </div>
     </section>
 
-    {% if has_expected %}
-    <!-- Bias Analysis -->
-    <section class="card p-6 mb-8 border-l-4 {% if within_hdi %}border-l-green-500{% else %}border-l-amber-500{% endif %}">
-        <h3 class="text-sm font-semibold text-slate-400 uppercase tracking-wide mb-4 flex items-center gap-2">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path></svg>
-            Bias Analysis (vs Expected Score {{ expected_score }})
-        </h3>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div>
-                <div class="text-xs text-slate-500 uppercase font-semibold mb-1">Expected Score</div>
-                <div class="text-2xl font-bold text-slate-800">{{ expected_score }}</div>
-            </div>
-            <div>
-                <div class="text-xs text-slate-500 uppercase font-semibold mb-1">Measured Bias</div>
-                <div class="text-2xl font-bold {% if bias > 0 %}text-amber-600{% elif bias < 0 %}text-blue-600{% else %}text-green-600{% endif %}">
-                    {{ "%+.2f"|format(bias) }}
-                </div>
-                <div class="text-xs text-slate-400 mt-1">
-                    Judge scores {% if bias > 0 %}higher{% elif bias < 0 %}lower{% else %}equal{% endif %} than ground truth
-                </div>
-            </div>
-            <div>
-                <div class="text-xs text-slate-500 uppercase font-semibold mb-1">Expected Within HDI</div>
-                <div class="text-2xl font-bold {% if within_hdi %}text-green-600{% else %}text-amber-600{% endif %}">
-                    {% if within_hdi %}Yes{% else %}No{% endif %}
-                </div>
-            </div>
-        </div>
-    </section>
-    {% endif %}
-
     <!-- Charts Grid -->
     <section class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
-        <!-- Posterior Distribution -->
+        {% if has_expected %}
         <div class="card p-6">
             <div class="flex justify-between items-center mb-4">
-                <h3 class="font-bold text-slate-700">Estimated True Score</h3>
-                <span class="text-xs font-mono bg-blue-50 text-blue-600 px-2 py-1 rounded">Bayesian Posterior</span>
+                <div class="flex items-center">
+                    <h3 class="font-bold text-slate-700">Accuracy Posterior (bias)</h3>
+                    <button class="help-btn no-print" onclick="toggleHelp('help-c-bias')">?</button>
+                </div>
+                <span class="text-xs font-mono bg-blue-50 text-blue-600 px-2 py-1 rounded">Bayesian</span>
+            </div>
+            <div class="help-text" id="help-c-bias">
+                This curve shows the <strong>probability distribution of the judge's systematic error</strong>, estimated by Bayesian analysis. The shaded region is the {{ hdi_pct }}% credible interval.
+                <br><br>
+                <strong>Dashed line at zero</strong> = a perfectly accurate judge. If the curve is centered there, the judge is accurate. If shifted right, it scores too high. If shifted left, too low.
             </div>
             <div class="relative h-64 w-full">
-                <canvas id="posteriorChart"></canvas>
+                <canvas id="biasChart"></canvas>
             </div>
             <div class="mt-4 text-center text-xs text-slate-500">
-                The shaded area represents the {{ hdi_pct }}% High Density Interval [{{ analysis.hdi_lower | round(2) }}, {{ analysis.hdi_upper | round(2) }}].
+                Shaded: {{ hdi_pct }}% CI [{{ "%+.2f"|format(analysis.bias_hdi[0]) }}, {{ "%+.2f"|format(analysis.bias_hdi[1]) }}]. Zero = perfectly accurate.
             </div>
         </div>
+        {% endif %}
 
-        <!-- Score Distribution -->
         <div class="card p-6">
             <div class="flex justify-between items-center mb-4">
-                <h3 class="font-bold text-slate-700">Observed Score Distribution</h3>
+                <div class="flex items-center">
+                    <h3 class="font-bold text-slate-700">Score Distribution</h3>
+                    <button class="help-btn no-print" onclick="toggleHelp('help-c-hist')">?</button>
+                </div>
                 <span class="text-xs font-mono bg-slate-100 text-slate-600 px-2 py-1 rounded">n={{ repeats }}</span>
+            </div>
+            <div class="help-text" id="help-c-hist">
+                How many times the judge gave each score (1 through 5) across {{ repeats }} evaluations of the same content. A consistent judge concentrates on one or two scores. A wide spread means the judge is inconsistent.
             </div>
             <div class="relative h-64 w-full">
                 <canvas id="histogramChart"></canvas>
             </div>
-            <div class="mt-4 text-center text-xs text-slate-500">
-                Frequency of scores across {{ repeats }} repeated evaluations.
-            </div>
         </div>
 
-        <!-- Judge Noise -->
         <div class="card p-6">
             <div class="flex justify-between items-center mb-4">
-                <h3 class="font-bold text-slate-700">Judge Measurement Noise</h3>
+                <div class="flex items-center">
+                    <h3 class="font-bold text-slate-700">Consistency Posterior (noise)</h3>
+                    <button class="help-btn no-print" onclick="toggleHelp('help-c-noise')">?</button>
+                </div>
                 <span class="text-xs font-mono bg-slate-100 text-slate-600 px-2 py-1 rounded">{{ oracle_model }}</span>
+            </div>
+            <div class="help-text" id="help-c-noise">
+                This curve shows the <strong>probability distribution of the judge's inconsistency</strong>, estimated by Bayesian analysis. The shaded region is the {{ hdi_pct }}% credible interval.
+                <br><br>
+                Values further left (lower noise) = more consistent. A noise of 0.3 means scores scatter &plusmn;0.3 around the average. Values above 1.0 indicate an unreliable judge.
             </div>
             <div class="relative h-64 w-full">
                 <canvas id="noiseChart"></canvas>
-            </div>
-            <div class="mt-4 text-center text-xs text-slate-500">
-                Estimated measurement uncertainty of the oracle judge.
             </div>
         </div>
     </section>
@@ -353,16 +383,19 @@
     <!-- Raw Scores Table -->
     <section class="card overflow-hidden mb-8">
         <div class="bg-slate-50 border-b px-6 py-4 flex justify-between items-center">
-            <h3 class="font-bold text-slate-700">Raw Scores</h3>
+            <div class="flex items-center">
+                <h3 class="font-bold text-slate-700">Raw Scores</h3>
+                <button class="help-btn no-print" onclick="toggleHelp('help-raw')">?</button>
+            </div>
             <span class="text-xs text-slate-500">{{ scores | length }} Evaluations</span>
+        </div>
+        <div class="help-text" id="help-raw" style="margin:0;border-radius:0;border-left:0;border-right:0;border-top:0;">
+            The actual score the judge gave on each of the {{ repeats }} evaluations. All evaluations used the exact same prompt and response, so any variation is the judge's inconsistency.
         </div>
         <div class="overflow-x-auto">
             <table class="w-full text-left text-sm">
                 <thead class="bg-white text-slate-500 border-b">
-                    <tr>
-                        <th class="px-6 py-3 w-16 text-center">#</th>
-                        <th class="px-6 py-3 w-32 text-center">Score</th>
-                    </tr>
+                    <tr><th class="px-6 py-3 w-16 text-center">#</th><th class="px-6 py-3 w-32 text-center">Score</th></tr>
                 </thead>
                 <tbody class="divide-y divide-slate-100">
                     {% for score in scores %}
@@ -377,221 +410,77 @@
     </section>
 
     <footer class="mt-12 text-center text-xs text-slate-400 pb-8">
-        MetaReason Calibration Report &middot; {{ timestamp[:4] }}
+        MetaReason Judge Calibration Report &middot; {{ timestamp[:4] }}
     </footer>
 
-    <!-- Chart.js Configuration -->
     <script>
+    function toggleHelp(id) {
+        var el = document.getElementById(id);
+        var wasOpen = el.classList.contains('open');
+        document.querySelectorAll('.help-text.open').forEach(function(h) { h.classList.remove('open'); });
+        document.querySelectorAll('.help-btn.active').forEach(function(b) { b.classList.remove('active'); });
+        if (!wasOpen) {
+            el.classList.add('open');
+            var btn = document.querySelector('[onclick="toggleHelp(\'' + id + '\')"]');
+            if (btn) btn.classList.add('active');
+        }
+    }
+
     (function() {
         const d = {{ chart_data | tojson }};
 
         const commonScatterOpts = {
-            responsive: true,
-            maintainAspectRatio: false,
+            responsive: true, maintainAspectRatio: false,
             plugins: { legend: { display: false } },
             scales: {
-                x: {
-                    type: 'linear',
-                    grid: { display: false },
-                    ticks: { callback: v => v.toFixed(1) }
-                },
-                y: {
-                    grid: { color: '#f1f5f9' },
-                    beginAtZero: true,
-                    ticks: { display: false }
-                }
+                x: { type: 'linear', grid: { display: false }, ticks: { callback: v => v.toFixed(1) } },
+                y: { grid: { color: '#f1f5f9' }, beginAtZero: true, ticks: { display: false } }
             }
         };
 
-        // --- Posterior Distribution ---
-        const posteriorPoints = d.posterior_x.map((x, i) => ({x: x, y: d.posterior_y[i]}));
-        new Chart(document.getElementById('posteriorChart'), {
+        {% if has_expected %}
+        const biasPoints = d.bias_x.map((x, i) => ({x: x, y: d.bias_y[i]}));
+        new Chart(document.getElementById('biasChart'), {
             type: 'scatter',
-            data: {
-                datasets: [{
-                    data: posteriorPoints,
-                    showLine: true,
-                    borderColor: '#4f46e5',
-                    borderWidth: 2,
-                    fill: false,
-                    pointRadius: 0,
-                    tension: 0.3
-                }]
-            },
+            data: { datasets: [{ data: biasPoints, showLine: true, borderColor: '#4f46e5', borderWidth: 2, fill: false, pointRadius: 0, tension: 0.3 }] },
             options: {
                 ...commonScatterOpts,
-                plugins: {
-                    legend: { display: false },
-                    annotation: {
-                        annotations: {
-                            hdiBox: {
-                                type: 'box',
-                                xMin: d.hdi_lower,
-                                xMax: d.hdi_upper,
-                                backgroundColor: 'rgba(79, 70, 229, 0.12)',
-                                borderWidth: 0
-                            },
-                            meanLine: {
-                                type: 'line',
-                                xMin: d.population_mean,
-                                xMax: d.population_mean,
-                                borderColor: '#ef4444',
-                                borderWidth: 1.5,
-                                borderDash: [5, 5],
-                                label: {
-                                    display: true,
-                                    content: 'Mean: ' + d.population_mean.toFixed(2),
-                                    position: 'start',
-                                    backgroundColor: 'rgba(239, 68, 68, 0.8)',
-                                    font: { size: 10 }
-                                }
-                            },
-                            medianLine: {
-                                type: 'line',
-                                xMin: d.population_median,
-                                xMax: d.population_median,
-                                borderColor: '#f59e0b',
-                                borderWidth: 1.5,
-                                borderDash: [5, 5],
-                                label: {
-                                    display: true,
-                                    content: 'Median: ' + d.population_median.toFixed(2),
-                                    position: 'end',
-                                    backgroundColor: 'rgba(245, 158, 11, 0.8)',
-                                    font: { size: 10 }
-                                }
-                            }
-                        }
-                    }
-                },
+                plugins: { legend: { display: false }, annotation: { annotations: {
+                    hdiBox: { type: 'box', xMin: d.bias_hdi_lower, xMax: d.bias_hdi_upper, backgroundColor: 'rgba(79, 70, 229, 0.12)', borderWidth: 0 },
+                    zeroLine: { type: 'line', xMin: 0, xMax: 0, borderColor: '#94a3b8', borderWidth: 1, borderDash: [4, 4], label: { display: true, content: 'Accurate', position: 'end', backgroundColor: 'rgba(148, 163, 184, 0.8)', font: { size: 10 } } },
+                    meanLine: { type: 'line', xMin: d.bias_mean, xMax: d.bias_mean, borderColor: '#ef4444', borderWidth: 1.5, borderDash: [5, 5], label: { display: true, content: 'Error: ' + (d.bias_mean >= 0 ? '+' : '') + d.bias_mean.toFixed(2), position: 'start', backgroundColor: 'rgba(239, 68, 68, 0.8)', font: { size: 10 } } }
+                } } },
                 scales: {
-                    x: {
-                        type: 'linear',
-                        grid: { display: false },
-                        title: { display: true, text: 'Quality Score', font: { size: 12 } },
-                        ticks: { callback: v => v.toFixed(1) }
-                    },
-                    y: {
-                        grid: { color: '#f1f5f9' },
-                        beginAtZero: true,
-                        title: { display: true, text: 'Density', font: { size: 12 } },
-                        ticks: { display: false }
-                    }
+                    x: { type: 'linear', grid: { display: false }, title: { display: true, text: 'Error (bias)', font: { size: 12 } }, ticks: { callback: v => (v >= 0 ? '+' : '') + v.toFixed(1) } },
+                    y: { grid: { color: '#f1f5f9' }, beginAtZero: true, title: { display: true, text: 'Density', font: { size: 12 } }, ticks: { display: false } }
                 }
             }
         });
+        {% endif %}
 
-        // --- Score Histogram ---
         new Chart(document.getElementById('histogramChart'), {
             type: 'bar',
-            data: {
-                labels: d.histogram_labels,
-                datasets: [{
-                    data: d.histogram_counts,
-                    backgroundColor: '#94a3b8',
-                    hoverBackgroundColor: '#4f46e5',
-                    borderRadius: 4
-                }]
-            },
+            data: { labels: d.histogram_labels, datasets: [{ data: d.histogram_counts, backgroundColor: '#94a3b8', hoverBackgroundColor: '#4f46e5', borderRadius: 4 }] },
             options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                plugins: {
-                    legend: { display: false },
-                    annotation: {
-                        annotations: {
-                            meanLine: {
-                                type: 'line',
-                                xMin: d.score_mean - 1,
-                                xMax: d.score_mean - 1,
-                                borderColor: '#ef4444',
-                                borderWidth: 2,
-                                borderDash: [5, 5],
-                                label: {
-                                    display: true,
-                                    content: 'Mean: ' + d.score_mean.toFixed(2),
-                                    position: 'start',
-                                    backgroundColor: 'rgba(239, 68, 68, 0.8)',
-                                    font: { size: 10 }
-                                }
-                            }
-                        }
-                    }
-                },
-                scales: {
-                    x: {
-                        grid: { display: false },
-                        title: { display: true, text: 'Score', font: { size: 12 } }
-                    },
-                    y: {
-                        grid: { color: '#f1f5f9' },
-                        beginAtZero: true,
-                        title: { display: true, text: 'Count', font: { size: 12 } },
-                        ticks: { stepSize: 1 }
-                    }
-                }
+                responsive: true, maintainAspectRatio: false,
+                plugins: { legend: { display: false }, annotation: { annotations: { meanLine: { type: 'line', xMin: d.score_mean - 1, xMax: d.score_mean - 1, borderColor: '#ef4444', borderWidth: 2, borderDash: [5, 5], label: { display: true, content: 'Mean: ' + d.score_mean.toFixed(2), position: 'start', backgroundColor: 'rgba(239, 68, 68, 0.8)', font: { size: 10 } } } } } },
+                scales: { x: { grid: { display: false }, title: { display: true, text: 'Score', font: { size: 12 } } }, y: { grid: { color: '#f1f5f9' }, beginAtZero: true, title: { display: true, text: 'Count', font: { size: 12 } }, ticks: { stepSize: 1 } } }
             }
         });
 
-        // --- Noise Distribution ---
         const noisePoints = d.noise_x.map((x, i) => ({x: x, y: d.noise_y[i]}));
         new Chart(document.getElementById('noiseChart'), {
             type: 'scatter',
-            data: {
-                datasets: [{
-                    data: noisePoints,
-                    showLine: true,
-                    borderColor: '#64748b',
-                    borderWidth: 2,
-                    fill: false,
-                    pointRadius: 0,
-                    tension: 0.3
-                }]
-            },
+            data: { datasets: [{ data: noisePoints, showLine: true, borderColor: '#64748b', borderWidth: 2, fill: false, pointRadius: 0, tension: 0.3 }] },
             options: {
                 ...commonScatterOpts,
-                plugins: {
-                    legend: { display: false },
-                    annotation: {
-                        annotations: {
-                            hdiBox: {
-                                type: 'box',
-                                xMin: d.noise_hdi_lower,
-                                xMax: d.noise_hdi_upper,
-                                backgroundColor: 'rgba(100, 116, 139, 0.12)',
-                                borderWidth: 0
-                            },
-                            meanLine: {
-                                type: 'line',
-                                xMin: d.noise_mean,
-                                xMax: d.noise_mean,
-                                borderColor: '#ef4444',
-                                borderWidth: 1.5,
-                                borderDash: [5, 5],
-                                label: {
-                                    display: true,
-                                    content: 'Mean: ' + d.noise_mean.toFixed(2),
-                                    position: 'start',
-                                    backgroundColor: 'rgba(239, 68, 68, 0.8)',
-                                    font: { size: 10 }
-                                }
-                            }
-                        }
-                    }
-                },
+                plugins: { legend: { display: false }, annotation: { annotations: {
+                    hdiBox: { type: 'box', xMin: d.noise_hdi_lower, xMax: d.noise_hdi_upper, backgroundColor: 'rgba(100, 116, 139, 0.12)', borderWidth: 0 },
+                    meanLine: { type: 'line', xMin: d.noise_mean, xMax: d.noise_mean, borderColor: '#ef4444', borderWidth: 1.5, borderDash: [5, 5], label: { display: true, content: 'Mean: ' + d.noise_mean.toFixed(2), position: 'start', backgroundColor: 'rgba(239, 68, 68, 0.8)', font: { size: 10 } } }
+                } } },
                 scales: {
-                    x: {
-                        type: 'linear',
-                        grid: { display: false },
-                        title: { display: true, text: 'Noise Magnitude', font: { size: 12 } },
-                        ticks: { callback: v => v.toFixed(2) }
-                    },
-                    y: {
-                        grid: { color: '#f1f5f9' },
-                        beginAtZero: true,
-                        title: { display: true, text: 'Density', font: { size: 12 } },
-                        ticks: { display: false }
-                    }
+                    x: { type: 'linear', grid: { display: false }, title: { display: true, text: 'Inconsistency (noise)', font: { size: 12 } }, ticks: { callback: v => v.toFixed(2) } },
+                    y: { grid: { color: '#f1f5f9' }, beginAtZero: true, title: { display: true, text: 'Density', font: { size: 12 } }, ticks: { display: false } }
                 }
             }
         });

--- a/src/metareason/reporting/templates/multi_judge_report.html.j2
+++ b/src/metareason/reporting/templates/multi_judge_report.html.j2
@@ -1,0 +1,512 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
+
+    <script>{{ chartjs_source }}</script>
+    <script>{{ chartjs_annotation_source }}</script>
+
+    <style>
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #f8fafc; -webkit-font-smoothing: antialiased; }
+        .card { background: white; border-radius: 12px; box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1); border: 1px solid #e2e8f0; }
+        .container { max-width: 80rem; margin: 0 auto; padding: 1.5rem; }
+
+        .grid { display: grid; gap: 1.5rem; }
+        .grid-2 { grid-template-columns: repeat(2, 1fr); }
+        .grid-3 { grid-template-columns: repeat(3, 1fr); }
+        .flex { display: flex; }
+        .items-center { align-items: center; }
+        .justify-between { justify-content: space-between; }
+        .gap-3 { gap: 0.75rem; }
+        .gap-4 { gap: 1rem; }
+
+        .p-5 { padding: 1.25rem; }
+        .p-6 { padding: 1.5rem; }
+        .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+        .px-4 { padding-left: 1rem; padding-right: 1rem; }
+        .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+        .py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+        .mb-2 { margin-bottom: 0.5rem; }
+        .mb-4 { margin-bottom: 1rem; }
+        .mb-6 { margin-bottom: 1.5rem; }
+        .mb-8 { margin-bottom: 2rem; }
+        .mt-4 { margin-top: 1rem; }
+        .mt-12 { margin-top: 3rem; }
+        .pb-8 { padding-bottom: 2rem; }
+
+        .text-xs { font-size: 0.75rem; }
+        .text-sm { font-size: 0.875rem; }
+        .text-lg { font-size: 1.125rem; }
+        .text-xl { font-size: 1.25rem; }
+        .text-2xl { font-size: 1.5rem; }
+        .text-3xl { font-size: 1.875rem; }
+        .font-bold { font-weight: 700; }
+        .font-semibold { font-weight: 600; }
+        .font-medium { font-weight: 500; }
+        .font-mono { font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+        .uppercase { text-transform: uppercase; }
+        .tracking-wider { letter-spacing: 0.05em; }
+        .text-center { text-align: center; }
+        .text-left { text-align: left; }
+        .text-right { text-align: right; }
+        .whitespace-pre-wrap { white-space: pre-wrap; }
+
+        .text-white { color: #fff; }
+        .text-slate-400 { color: #94a3b8; }
+        .text-slate-500 { color: #64748b; }
+        .text-slate-600 { color: #475569; }
+        .text-slate-700 { color: #334155; }
+        .text-slate-800 { color: #1e293b; }
+        .text-slate-900 { color: #0f172a; }
+        .text-indigo-600 { color: #4f46e5; }
+        .text-indigo-700 { color: #4338ca; }
+        .text-green-600 { color: #16a34a; }
+        .text-amber-600 { color: #d97706; }
+        .text-red-600 { color: #dc2626; }
+        .text-blue-600 { color: #2563eb; }
+        .bg-slate-50 { background-color: #f8fafc; }
+        .bg-slate-100 { background-color: #f1f5f9; }
+        .bg-blue-50 { background-color: #eff6ff; }
+
+        .border { border: 1px solid #e2e8f0; }
+        .border-b { border-bottom: 1px solid #e2e8f0; }
+        .border-l-4 { border-left: 4px solid; }
+        .border-l-blue-500 { border-left-color: #3b82f6; }
+        .border-l-indigo-500 { border-left-color: #6366f1; }
+        .border-l-purple-500 { border-left-color: #a855f7; }
+        .border-l-slate-400 { border-left-color: #94a3b8; }
+        .border-l-green-500 { border-left-color: #22c55e; }
+        .border-l-amber-500 { border-left-color: #f59e0b; }
+        .border-l-red-500 { border-left-color: #ef4444; }
+        .rounded-lg { border-radius: 0.5rem; }
+        .rounded-xl { border-radius: 0.75rem; }
+        .overflow-hidden { overflow: hidden; }
+        .overflow-x-auto { overflow-x: auto; }
+
+        .w-full { width: 100%; }
+        .h-64 { height: 16rem; }
+        .relative { position: relative; }
+
+        .shadow-lg { box-shadow: 0 10px 15px -3px rgba(0,0,0,.1), 0 4px 6px -4px rgba(0,0,0,.1); }
+        .transition { transition: all 150ms ease; }
+        .hover-bg:hover { background-color: #f8fafc; }
+
+        .divide-y > * + * { border-top: 1px solid #f1f5f9; }
+
+        pre { font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+        .max-h-24 { max-height: 6rem; overflow-y: auto; }
+
+        /* Help button styles */
+        .help-btn {
+            display: inline-flex; align-items: center; justify-content: center;
+            width: 20px; height: 20px; border-radius: 50%;
+            background: #e2e8f0; color: #64748b; border: none;
+            font-size: 12px; font-weight: 700; cursor: pointer;
+            margin-left: 6px; vertical-align: middle; line-height: 1;
+            transition: all 150ms ease; flex-shrink: 0;
+        }
+        .help-btn:hover { background: #4f46e5; color: white; }
+        .help-btn.active { background: #4f46e5; color: white; }
+        .help-text {
+            display: none; margin-top: 0.75rem; padding: 0.75rem 1rem;
+            background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px;
+            font-size: 0.8125rem; line-height: 1.6; color: #475569;
+            animation: helpFadeIn 150ms ease;
+        }
+        .help-text.open { display: block; }
+        .help-text strong { color: #1e293b; }
+        @keyframes helpFadeIn {
+            from { opacity: 0; transform: translateY(-4px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        @media (max-width: 768px) {
+            .grid-2, .grid-3 { grid-template-columns: 1fr; }
+        }
+
+        @media print {
+            body { background: white; }
+            .card { box-shadow: none; border: 1px solid #ddd; break-inside: avoid; }
+            .no-print { display: none; }
+            .help-btn { display: none; }
+            .help-text { display: none !important; }
+        }
+    </style>
+</head>
+<body class="text-slate-800 container">
+
+    <!-- Header -->
+    <header class="flex justify-between items-center mb-8" style="flex-wrap:wrap;gap:1rem;">
+        <div>
+            <div class="text-xs font-bold tracking-wider text-indigo-600 uppercase mb-2">MetaReason Multi-Judge Report</div>
+            <h1 class="text-3xl font-bold text-slate-900">{{ spec_id }}</h1>
+            <p class="text-slate-500 text-sm mt-4">Generated: {{ timestamp }}</p>
+        </div>
+        <div class="flex gap-3">
+            <div class="flex" style="flex-direction:column;align-items:flex-end;" class="px-4 py-2 bg-white rounded-lg border">
+                <span class="text-xs text-slate-500 uppercase font-semibold">Judges</span>
+                <span class="font-bold text-lg">{{ n_judges }}</span>
+            </div>
+            <div class="flex" style="flex-direction:column;align-items:flex-end;" class="px-4 py-2 bg-white rounded-lg border">
+                <span class="text-xs text-slate-500 uppercase font-semibold">Repeats</span>
+                <span class="font-bold text-lg">{{ repeats }}</span>
+            </div>
+            <button onclick="window.print()" class="no-print px-4 py-2 rounded-lg font-medium text-sm text-white" style="background:#0f172a;">Print</button>
+        </div>
+    </header>
+
+    <!-- Per-Judge Assessment Cards -->
+    <section class="mb-8">
+        <div class="flex items-center mb-4">
+            <h2 class="font-bold text-slate-700 text-lg">Per-Judge Assessment</h2>
+            <button class="help-btn no-print" onclick="toggleHelp('help-cards')">?</button>
+        </div>
+        <div class="help-text" id="help-cards">
+            Each card summarizes one judge's calibration. The judge was asked to score the same fixed prompt+response {{ repeats }} times, so any variation in scores reflects the <strong>judge's behavior</strong>, not differences in content.
+            <br><br>
+            <strong>Accuracy (bias)</strong> &mdash; How far the judge's average score is from the known correct score{% if has_expected %} of {{ expected_score }}{% endif %}. A value of <strong>+0.5</strong> means the judge scores half a point too high on average. A value near <strong>0</strong> means the judge is well-calibrated. This is a <em>systematic</em> error &mdash; the judge consistently leans one direction.
+            <br><br>
+            <strong>Consistency (noise)</strong> &mdash; How much the judge's scores scatter across repeated evaluations of the same content. A value of <strong>&plusmn;0.3</strong> means scores typically wander &plusmn;0.3 points around the judge's average. Lower is better &mdash; a consistent judge gives similar scores each time.
+            <br><br>
+            <strong>{{ hdi_pct }}% CI</strong> &mdash; The credible interval from Bayesian analysis. "{{ hdi_pct }}% CI: [+0.2, +0.8]" means we are {{ hdi_pct }}% confident the true value lies in that range. Narrower intervals mean more certainty.
+            <br><br>
+            <strong>Border color</strong> &mdash; <span style="color:#22c55e;">Green</span> = well-calibrated. <span style="color:#d97706;">Amber</span> = usable with caveats. <span style="color:#ef4444;">Red</span> = problematic.
+        </div>
+        <div class="grid grid-{{ [n_judges, 3] | min }}">
+            {% for name, info in multi_judge.judges.items() %}
+            <div class="card p-6 border-l-4 {% if judge_verdicts[name].verdict_class == 'good' %}border-l-green-500{% elif judge_verdicts[name].verdict_class == 'warn' %}border-l-amber-500{% else %}border-l-red-500{% endif %}">
+                <h3 class="font-bold text-indigo-700 mb-4">{{ name }}</h3>
+                {% if has_expected %}
+                <div class="mb-2">
+                    <span class="text-xs text-slate-500 uppercase font-semibold">Accuracy (bias)</span>
+                    <div class="text-lg font-bold font-mono {% if info.bias_mean > 0.2 %}text-amber-600{% elif info.bias_mean < -0.2 %}text-blue-600{% else %}text-green-600{% endif %}">
+                        {{ "%+.2f"|format(info.bias_mean) }}
+                    </div>
+                    <div class="text-xs text-slate-400">{{ hdi_pct }}% CI: [{{ "%+.2f"|format(info.bias_hdi[0]) }}, {{ "%+.2f"|format(info.bias_hdi[1]) }}]</div>
+                </div>
+                {% endif %}
+                <div class="mb-2">
+                    <span class="text-xs text-slate-500 uppercase font-semibold">Consistency (noise)</span>
+                    <div class="text-lg font-bold font-mono">&plusmn;{{ "%.2f"|format(info.noise_mean) }}</div>
+                    <div class="text-xs text-slate-400">{{ hdi_pct }}% CI: [{{ "%.2f"|format(info.noise_hdi[0]) }}, {{ "%.2f"|format(info.noise_hdi[1]) }}]</div>
+                </div>
+                <div class="mt-4 text-sm font-semibold {% if judge_verdicts[name].verdict_class == 'good' %}text-green-600{% elif judge_verdicts[name].verdict_class == 'warn' %}text-amber-600{% else %}text-red-600{% endif %}">
+                    {{ judge_verdicts[name].verdict }}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </section>
+
+    <!-- Judge Comparison Table -->
+    <section class="card overflow-hidden mb-8">
+        <div class="bg-slate-50 border-b px-4 py-3 flex justify-between items-center">
+            <div class="flex items-center">
+                <h3 class="font-bold text-slate-700">Judge Comparison</h3>
+                <button class="help-btn no-print" onclick="toggleHelp('help-table')">?</button>
+            </div>
+            <span class="text-xs text-slate-500">{{ n_judges }} Judges &middot; {{ repeats }} repeats each</span>
+        </div>
+        <div class="help-text" id="help-table" style="margin:0;border-radius:0;border-left:0;border-right:0;border-top:0;">
+            <strong>Accuracy (bias)</strong> &mdash; Systematic scoring error vs the true score. Positive = scores too high (generous), negative = scores too low (harsh). Color-coded: <span style="color:#16a34a;">green</span> for low (&lt;0.3), <span style="color:#d97706;">amber</span> for high positive, <span style="color:#2563eb;">blue</span> for high negative.
+            <br><br>
+            <strong>Consistency (noise)</strong> &mdash; How much scores scatter across repeated evaluations of identical content. Lower = more predictable. A value of 0.5 on a 1&ndash;5 scale means scores wander by about half a point.
+            <br><br>
+            <strong>Consistency Weight</strong> &mdash; How much this judge's scores count toward the consensus. Computed as <code>1/noise&sup2;</code>, normalized so all weights sum to 100%. More consistent judges get more weight.
+            <br><br>
+            <strong>Raw Mean</strong> &mdash; The judge's simple average score before any corrections. Compare to the expected score{% if has_expected %} of {{ expected_score }}{% endif %} to see raw accuracy.
+            <br><br>
+            <strong>N</strong> &mdash; Number of successful evaluations (out of {{ repeats }} configured repeats).
+        </div>
+        <div class="overflow-x-auto">
+            <table class="w-full text-left text-sm">
+                <thead class="bg-white text-slate-500 border-b">
+                    <tr>
+                        <th class="px-4 py-3">Judge</th>
+                        <th class="px-4 py-3 text-right">Accuracy (bias)</th>
+                        <th class="px-4 py-3 text-right">Consistency (noise)</th>
+                        <th class="px-4 py-3 text-right">Consistency Weight</th>
+                        <th class="px-4 py-3 text-right">Raw Mean</th>
+                        <th class="px-4 py-3 text-right">N</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y">
+                    {% for name, info in multi_judge.judges.items() %}
+                    <tr class="hover-bg transition">
+                        <td class="px-4 py-3 font-medium text-indigo-700">{{ name }}</td>
+                        <td class="px-4 py-3 text-right font-mono {% if info.bias_mean > 0.2 %}text-amber-600{% elif info.bias_mean < -0.2 %}text-blue-600{% else %}text-green-600{% endif %}">{{ "%+.3f" | format(info.bias_mean) }}</td>
+                        <td class="px-4 py-3 text-right font-mono">{{ "%.3f" | format(info.noise_mean) }}</td>
+                        <td class="px-4 py-3 text-right font-mono font-semibold">{{ "%.1f%%" | format(info.consistency_weight * 100) }}</td>
+                        <td class="px-4 py-3 text-right font-mono">{{ "%.2f" | format(info.raw_score_mean) }}</td>
+                        <td class="px-4 py-3 text-right">{{ info.n_evaluations }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    {% if recommendations %}
+    <!-- Recommendations -->
+    <section class="card p-6 mb-8 border-l-4 border-l-amber-500">
+        <div class="flex items-center mb-4">
+            <h3 class="text-sm font-semibold text-slate-400 uppercase tracking-wider">Recommendations</h3>
+            <button class="help-btn no-print" onclick="toggleHelp('help-recs')">?</button>
+        </div>
+        <div class="help-text" id="help-recs">
+            Automated suggestions based on noise thresholds. Judges with noise above <strong>1.0</strong> on a 1&ndash;5 scale are flagged as unreliable &mdash; their scores vary so widely that they add more uncertainty than information. Consider removing them and re-running, or investigating why (e.g., high temperature setting, ambiguous rubric).
+        </div>
+        <ul style="list-style:disc;padding-left:1.5rem;">
+            {% for rec in recommendations %}
+            <li class="text-sm text-slate-700 mb-2">{{ rec }}</li>
+            {% endfor %}
+        </ul>
+    </section>
+    {% endif %}
+
+    <!-- Charts Grid -->
+    <section class="grid grid-2 mb-8">
+        <!-- Per-Judge Score Distributions -->
+        <div class="card p-6">
+            <div class="flex justify-between items-center mb-4">
+                <div class="flex items-center">
+                    <h3 class="font-bold text-slate-700">Score Distributions</h3>
+                    <button class="help-btn no-print" onclick="toggleHelp('help-hist')">?</button>
+                </div>
+                <span class="text-xs font-mono bg-slate-100 text-slate-600 px-3 py-2 rounded-lg">n={{ repeats }}</span>
+            </div>
+            <div class="help-text" id="help-hist">
+                Each color represents a different judge. The bars show how many times each judge gave a particular score (1 through 5) across all repeats.
+                <br><br>
+                <strong>What to look for:</strong><br>
+                &bull; <strong>Spread</strong> &mdash; A judge whose bars span multiple scores is inconsistent (high noise). One concentrated at a single score is consistent.<br>
+                &bull; <strong>Position</strong> &mdash; Judges whose bars cluster at higher scores have positive bias (generous), and vice versa.<br>
+                &bull; <strong>Overlap</strong> &mdash; When judges' distributions overlap, they broadly agree. When shifted apart, there's systematic bias between them.
+            </div>
+            <div class="relative h-64 w-full">
+                <canvas id="histogramChart"></canvas>
+            </div>
+        </div>
+
+        <!-- Per-Judge Accuracy Posteriors (bias) -->
+        <div class="card p-6">
+            <div class="flex justify-between items-center mb-4">
+                <div class="flex items-center">
+                    <h3 class="font-bold text-slate-700">Accuracy Posteriors (bias)</h3>
+                    <button class="help-btn no-print" onclick="toggleHelp('help-bias')">?</button>
+                </div>
+                <span class="text-xs font-mono bg-blue-50 text-blue-600 px-3 py-2 rounded-lg">{{ hdi_pct }}% HDI</span>
+            </div>
+            <div class="help-text" id="help-bias">
+                Each curve shows the <strong>probability distribution of a judge's systematic error</strong> (bias), estimated by the Bayesian model. The dashed line at zero represents a perfectly accurate judge.
+                <br><br>
+                <strong>How to read it:</strong><br>
+                &bull; A curve <strong>centered on zero</strong> = the judge is accurate<br>
+                &bull; A curve <strong>shifted right</strong> = the judge scores too high (generous)<br>
+                &bull; A curve <strong>shifted left</strong> = the judge scores too low (harsh)<br>
+                &bull; A <strong>narrow, tall</strong> curve = we're confident about the bias estimate<br>
+                &bull; A <strong>wide, flat</strong> curve = more uncertainty (need more repeats)
+                <br><br>
+                The x-axis shows bias in score points. A bias of +0.5 means the judge averages half a point above the true score.
+            </div>
+            <div class="relative h-64 w-full">
+                <canvas id="biasPosteriorChart"></canvas>
+            </div>
+            <div class="mt-4 text-center text-xs text-slate-500">
+                Per-judge accuracy distributions. Dashed line at zero = perfectly accurate.
+            </div>
+        </div>
+
+        <!-- Per-Judge Consistency Posteriors (noise) -->
+        <div class="card p-6">
+            <div class="flex justify-between items-center mb-4">
+                <div class="flex items-center">
+                    <h3 class="font-bold text-slate-700">Consistency Posteriors (noise)</h3>
+                    <button class="help-btn no-print" onclick="toggleHelp('help-noise')">?</button>
+                </div>
+                <span class="text-xs font-mono bg-slate-100 text-slate-600 px-3 py-2 rounded-lg">{{ hdi_pct }}% HDI</span>
+            </div>
+            <div class="help-text" id="help-noise">
+                Each curve shows the <strong>probability distribution of a judge's inconsistency</strong> (noise), estimated by the Bayesian model.
+                <br><br>
+                <strong>How to read it:</strong><br>
+                &bull; A curve <strong>further left</strong> (lower values) = a more consistent judge<br>
+                &bull; A curve <strong>further right</strong> (higher values) = a noisier, less predictable judge<br>
+                &bull; A judge with noise of 0.3 gives scores that scatter &plusmn;0.3 around its average<br>
+                &bull; If two judges' curves overlap heavily, they have similar consistency
+                <br><br>
+                Noise cannot be zero (all measurement has some uncertainty), but lower is always better. Judges with noise above 1.0 on a 1&ndash;5 scale are generally unreliable.
+            </div>
+            <div class="relative h-64 w-full">
+                <canvas id="noisePosteriorChart"></canvas>
+            </div>
+            <div class="mt-4 text-center text-xs text-slate-500">
+                Per-judge consistency distributions. Further left = more consistent.
+            </div>
+        </div>
+    </section>
+
+    {% if not has_expected and multi_judge.true_quality_mean is defined %}
+    <!-- Estimated Quality (secondary, when no expected_score) -->
+    <section class="card p-6 mb-8">
+        <div class="flex items-center mb-4">
+            <h3 class="text-sm font-semibold text-slate-400 uppercase tracking-wider">Estimated Quality (secondary)</h3>
+            <button class="help-btn no-print" onclick="toggleHelp('help-quality')">?</button>
+        </div>
+        <div class="help-text" id="help-quality">
+            When no <strong>expected score</strong> is provided, the model estimates the true quality as a secondary output. This is less useful than the per-judge assessments above &mdash; it answers "what's the response quality?" rather than "which judge should I use?"
+            <br><br>
+            To get accuracy (bias) measurements, re-run calibration with <code>expected_score</code> set in your YAML spec.
+        </div>
+        <div class="grid grid-3">
+            <div>
+                <div class="text-xs text-slate-500 uppercase font-semibold mb-2">True Quality Mean</div>
+                <div class="text-2xl font-bold">{{ multi_judge.true_quality_mean | round(3) }}</div>
+            </div>
+            <div>
+                <div class="text-xs text-slate-500 uppercase font-semibold mb-2">{{ hdi_pct }}% HDI</div>
+                <div class="text-2xl font-bold">{{ multi_judge.hdi_lower | round(2) }} &ndash; {{ multi_judge.hdi_upper | round(2) }}</div>
+            </div>
+            <div>
+                <div class="text-xs text-slate-500 uppercase font-semibold mb-2">Bias-Corrected Score</div>
+                <div class="text-2xl font-bold">{{ multi_judge.bias_corrected_weighted_score | round(3) }}</div>
+            </div>
+        </div>
+    </section>
+    {% endif %}
+
+    <!-- Prompt/Response Context -->
+    <section class="card p-6 mb-8">
+        <div class="flex items-center mb-4">
+            <h3 class="text-sm font-semibold text-slate-400 uppercase tracking-wider">Fixed Prompt &amp; Response</h3>
+            <button class="help-btn no-print" onclick="toggleHelp('help-context')">?</button>
+        </div>
+        <div class="help-text" id="help-context">
+            This is the exact prompt and response that was evaluated. Every judge evaluates the <strong>same fixed content</strong> repeatedly, so that differences in scores reflect judge behavior (accuracy and consistency) rather than differences in what's being evaluated.
+        </div>
+        <div class="mb-4">
+            <div class="text-xs text-slate-500 uppercase font-semibold mb-2">Prompt</div>
+            <pre class="text-xs text-slate-600 bg-slate-50 rounded-lg p-5 whitespace-pre-wrap max-h-24">{{ prompt }}</pre>
+        </div>
+        <div>
+            <div class="text-xs text-slate-500 uppercase font-semibold mb-2">Response</div>
+            <pre class="text-xs text-slate-600 bg-slate-50 rounded-lg p-5 whitespace-pre-wrap max-h-24">{{ response }}</pre>
+        </div>
+    </section>
+
+    <footer class="mt-12 text-center text-xs text-slate-400 pb-8">
+        MetaReason Multi-Judge Report &middot; {{ timestamp[:4] }}
+    </footer>
+
+    <script>
+    // Help button toggle
+    function toggleHelp(id) {
+        var el = document.getElementById(id);
+        var wasOpen = el.classList.contains('open');
+        document.querySelectorAll('.help-text.open').forEach(function(h) { h.classList.remove('open'); });
+        document.querySelectorAll('.help-btn.active').forEach(function(b) { b.classList.remove('active'); });
+        if (!wasOpen) {
+            el.classList.add('open');
+            var btn = document.querySelector('[onclick="toggleHelp(\'' + id + '\')"]');
+            if (btn) btn.classList.add('active');
+        }
+    }
+
+    (function() {
+        const d = {{ chart_data | tojson }};
+        const COLORS = ['#4f46e5', '#ef4444', '#22c55e', '#f59e0b', '#8b5cf6', '#06b6d4', '#ec4899'];
+
+        // --- Per-Judge Histograms ---
+        const histDatasets = d.judge_names.map((name, i) => ({
+            label: name,
+            data: d.judge_histograms[name],
+            backgroundColor: COLORS[i % COLORS.length] + '80',
+            borderColor: COLORS[i % COLORS.length],
+            borderWidth: 1,
+            borderRadius: 2
+        }));
+        new Chart(document.getElementById('histogramChart'), {
+            type: 'bar',
+            data: { labels: d.histogram_labels, datasets: histDatasets },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { position: 'top', labels: { boxWidth: 12, font: { size: 10 } } } },
+                scales: {
+                    x: { grid: { display: false }, title: { display: true, text: 'Score' } },
+                    y: { grid: { color: '#f1f5f9' }, beginAtZero: true, title: { display: true, text: 'Count' }, ticks: { stepSize: 1 } }
+                }
+            }
+        });
+
+        // --- Accuracy Posterior KDEs (bias) ---
+        const biasDatasets = d.judge_names.map((name, i) => {
+            const bp = d.bias_posteriors[name];
+            return {
+                label: name,
+                data: bp.x.map((x, j) => ({x: x, y: bp.y[j]})),
+                showLine: true,
+                borderColor: COLORS[i % COLORS.length],
+                borderWidth: 2,
+                fill: false,
+                pointRadius: 0,
+                tension: 0.3
+            };
+        });
+        new Chart(document.getElementById('biasPosteriorChart'), {
+            type: 'scatter',
+            data: { datasets: biasDatasets },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { position: 'top', labels: { boxWidth: 12, font: { size: 10 } } },
+                    annotation: {
+                        annotations: {
+                            zeroLine: { type: 'line', xMin: 0, xMax: 0, borderColor: '#94a3b8', borderWidth: 1, borderDash: [4, 4] }
+                        }
+                    }
+                },
+                scales: {
+                    x: { type: 'linear', grid: { display: false }, title: { display: true, text: 'Error (bias)' }, ticks: { callback: v => (v >= 0 ? '+' : '') + v.toFixed(1) } },
+                    y: { grid: { color: '#f1f5f9' }, beginAtZero: true, title: { display: true, text: 'Density' }, ticks: { display: false } }
+                }
+            }
+        });
+
+        // --- Consistency Posterior KDEs (noise) ---
+        const noiseDatasets = d.judge_names.map((name, i) => {
+            const np_data = d.noise_posteriors[name];
+            return {
+                label: name,
+                data: np_data.x.map((x, j) => ({x: x, y: np_data.y[j]})),
+                showLine: true,
+                borderColor: COLORS[i % COLORS.length],
+                borderWidth: 2,
+                fill: false,
+                pointRadius: 0,
+                tension: 0.3
+            };
+        });
+        new Chart(document.getElementById('noisePosteriorChart'), {
+            type: 'scatter',
+            data: { datasets: noiseDatasets },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { position: 'top', labels: { boxWidth: 12, font: { size: 10 } } }
+                },
+                scales: {
+                    x: { type: 'linear', grid: { display: false }, title: { display: true, text: 'Inconsistency (noise)' }, ticks: { callback: v => v.toFixed(2) } },
+                    y: { grid: { color: '#f1f5f9' }, beginAtZero: true, title: { display: true, text: 'Density' }, ticks: { display: false } }
+                }
+            }
+        });
+    })();
+    </script>
+</body>
+</html>

--- a/tests/test_agreement.py
+++ b/tests/test_agreement.py
@@ -1,0 +1,414 @@
+import numpy as np
+import pytest
+
+from metareason.analysis.agreement import (
+    compute_agreement_summary,
+    compute_krippendorff_alpha,
+    compute_pairwise_correlations,
+    extract_scores_by_oracle,
+)
+from metareason.oracles.oracle_base import EvaluationResult
+from metareason.pipeline.runner import SampleResult
+
+
+def _make_sample_result(evaluations_dict):
+    """Helper to build a SampleResult with the given oracle->score mapping."""
+    evals = {
+        name: EvaluationResult(score=score, explanation="ok")
+        for name, score in evaluations_dict.items()
+    }
+    return SampleResult(
+        sample_params={"p": 0},
+        original_prompt="prompt",
+        final_response="response",
+        evaluations=evals,
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_pairwise_correlations
+# ---------------------------------------------------------------------------
+
+
+class TestComputePairwiseCorrelations:
+    def test_perfect_positive_correlation(self):
+        scores = {
+            "judge_a": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "judge_b": [1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+        result = compute_pairwise_correlations(scores)
+
+        assert ("judge_a", "judge_b") in result["pearson"]
+        assert result["pearson"][("judge_a", "judge_b")] == pytest.approx(1.0)
+        assert result["spearman"][("judge_a", "judge_b")] == pytest.approx(1.0)
+
+    def test_perfect_negative_correlation(self):
+        scores = {
+            "judge_a": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "judge_b": [5.0, 4.0, 3.0, 2.0, 1.0],
+        }
+        result = compute_pairwise_correlations(scores)
+
+        assert result["pearson"][("judge_a", "judge_b")] == pytest.approx(-1.0)
+        assert result["spearman"][("judge_a", "judge_b")] == pytest.approx(-1.0)
+
+    def test_no_correlation(self):
+        # Orthogonal vectors have zero Pearson correlation
+        scores = {
+            "judge_a": [1.0, 0.0, -1.0, 0.0],
+            "judge_b": [0.0, 1.0, 0.0, -1.0],
+        }
+        result = compute_pairwise_correlations(scores)
+
+        assert result["pearson"][("judge_a", "judge_b")] == pytest.approx(0.0, abs=0.01)
+
+    def test_with_none_values_still_computes(self):
+        """None values are filtered; enough remaining pairs should compute."""
+        scores = {
+            "judge_a": [1.0, None, 3.0, 4.0, 5.0],
+            "judge_b": [1.0, 2.0, 3.0, None, 5.0],
+        }
+        result = compute_pairwise_correlations(scores)
+
+        # Paired non-None: indices 0, 2, 4 -> (1,1), (3,3), (5,5)
+        assert result["pearson"][("judge_a", "judge_b")] == pytest.approx(1.0)
+        assert result["spearman"][("judge_a", "judge_b")] == pytest.approx(1.0)
+
+    def test_too_few_pairs_returns_none(self):
+        """Fewer than 3 valid pairs should yield None."""
+        scores = {
+            "judge_a": [1.0, None, None, None],
+            "judge_b": [None, 2.0, None, 4.0],
+        }
+        result = compute_pairwise_correlations(scores)
+
+        assert result["pearson"][("judge_a", "judge_b")] is None
+        assert result["spearman"][("judge_a", "judge_b")] is None
+
+    def test_three_judges_produces_three_pairs(self):
+        scores = {
+            "a": [1.0, 2.0, 3.0],
+            "b": [1.0, 2.0, 3.0],
+            "c": [3.0, 2.0, 1.0],
+        }
+        result = compute_pairwise_correlations(scores)
+
+        assert len(result["pearson"]) == 3
+        assert len(result["spearman"]) == 3
+
+    def test_two_judges_minimum(self):
+        """Two judges is the minimum for pairwise correlation."""
+        scores = {
+            "x": [1.0, 2.0, 3.0],
+            "y": [2.0, 4.0, 6.0],
+        }
+        result = compute_pairwise_correlations(scores)
+
+        assert len(result["pearson"]) == 1
+        assert result["pearson"][("x", "y")] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# compute_krippendorff_alpha
+# ---------------------------------------------------------------------------
+
+
+class TestComputeKrippendorffAlpha:
+    def test_perfect_agreement_returns_one(self):
+        scores = {
+            "judge_a": [3.0, 3.0, 3.0, 3.0],
+            "judge_b": [3.0, 3.0, 3.0, 3.0],
+        }
+        alpha = compute_krippendorff_alpha(scores)
+        assert alpha == pytest.approx(1.0)
+
+    def test_perfect_agreement_varying_scores(self):
+        """Judges agree perfectly but scores vary across units."""
+        scores = {
+            "judge_a": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "judge_b": [1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+        alpha = compute_krippendorff_alpha(scores)
+        assert alpha == pytest.approx(1.0)
+
+    def test_no_agreement_alpha_below_perfect(self):
+        """Independent random scores should give alpha well below 1."""
+        rng = np.random.default_rng(42)
+        n = 20
+        scores = {
+            "judge_a": rng.uniform(1.0, 5.0, n).tolist(),
+            "judge_b": rng.uniform(1.0, 5.0, n).tolist(),
+        }
+        alpha = compute_krippendorff_alpha(scores)
+        # Random scores -> alpha should be strictly less than 1.0
+        assert alpha < 1.0
+
+    def test_systematic_disagreement_lower_than_agreement(self):
+        """Opposed scores should yield lower alpha than agreeing scores."""
+        agreeing = {
+            "judge_a": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "judge_b": [1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+        disagreeing = {
+            "judge_a": [1.0, 5.0, 1.0, 5.0, 1.0],
+            "judge_b": [5.0, 1.0, 5.0, 1.0, 5.0],
+        }
+        alpha_agree = compute_krippendorff_alpha(agreeing)
+        alpha_disagree = compute_krippendorff_alpha(disagreeing)
+        assert alpha_agree > alpha_disagree
+
+    def test_missing_data_handling(self):
+        """None values should be treated as missing, not crash."""
+        scores = {
+            "judge_a": [1.0, 2.0, None, 4.0, 5.0],
+            "judge_b": [1.0, 2.0, 3.0, 4.0, None],
+        }
+        alpha = compute_krippendorff_alpha(scores)
+        # Agreement is perfect on the overlapping set
+        assert alpha == pytest.approx(1.0)
+
+    def test_all_missing_returns_one(self):
+        """If no valid pairs exist, function returns 1.0 by convention."""
+        scores = {
+            "judge_a": [None, None],
+            "judge_b": [None, None],
+        }
+        alpha = compute_krippendorff_alpha(scores)
+        assert alpha == pytest.approx(1.0)
+
+    def test_single_unit_returns_one(self):
+        """Only one unit with both raters present -> d_o_den = 0 -> returns 1.0."""
+        scores = {
+            "judge_a": [3.0],
+            "judge_b": [3.0],
+        }
+        alpha = compute_krippendorff_alpha(scores)
+        assert alpha == pytest.approx(1.0)
+
+    def test_three_judges_agreement(self):
+        scores = {
+            "a": [1.0, 2.0, 3.0, 4.0],
+            "b": [1.0, 2.0, 3.0, 4.0],
+            "c": [1.0, 2.0, 3.0, 4.0],
+        }
+        alpha = compute_krippendorff_alpha(scores)
+        assert alpha == pytest.approx(1.0)
+
+    def test_two_judge_minimum(self):
+        """Two judges is the minimum for Krippendorff's alpha."""
+        scores = {
+            "x": [1.0, 3.0, 5.0],
+            "y": [1.0, 3.0, 5.0],
+        }
+        alpha = compute_krippendorff_alpha(scores)
+        assert alpha == pytest.approx(1.0)
+
+    def test_ragged_data_different_lengths(self):
+        """Handles oracles with different numbers of scores."""
+        scores = {
+            "judge_a": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "judge_b": [1.0, 2.0, 3.0],
+        }
+        # judge_b is shorter -> units 3,4 have only one rater -> skipped
+        alpha = compute_krippendorff_alpha(scores)
+        assert alpha == pytest.approx(1.0)
+
+    def test_partial_agreement(self):
+        """Partial agreement should yield alpha between 0 and 1."""
+        scores = {
+            "judge_a": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "judge_b": [1.5, 2.5, 3.5, 4.5, 4.5],
+        }
+        alpha = compute_krippendorff_alpha(scores)
+        assert 0.0 < alpha < 1.0
+
+
+# ---------------------------------------------------------------------------
+# compute_agreement_summary
+# ---------------------------------------------------------------------------
+
+
+class TestComputeAgreementSummary:
+    def test_returns_all_expected_keys(self):
+        scores = {
+            "judge_a": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "judge_b": [1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+        summary = compute_agreement_summary(scores)
+
+        expected_keys = {
+            "krippendorff_alpha",
+            "pairwise_correlations",
+            "mean_pearson",
+            "mean_spearman",
+            "oracle_stats",
+            "n_judges",
+        }
+        assert set(summary.keys()) == expected_keys
+
+    def test_n_judges_correct(self):
+        scores = {
+            "a": [1.0, 2.0, 3.0],
+            "b": [1.0, 2.0, 3.0],
+            "c": [1.0, 2.0, 3.0],
+        }
+        summary = compute_agreement_summary(scores)
+        assert summary["n_judges"] == 3
+
+    def test_oracle_stats_populated(self):
+        scores = {
+            "judge_a": [1.0, 2.0, 3.0],
+            "judge_b": [4.0, 4.0, 4.0],
+        }
+        summary = compute_agreement_summary(scores)
+
+        assert "judge_a" in summary["oracle_stats"]
+        assert "judge_b" in summary["oracle_stats"]
+
+        stats_a = summary["oracle_stats"]["judge_a"]
+        assert stats_a["mean"] == pytest.approx(2.0)
+        assert stats_a["n"] == 3
+        assert stats_a["std"] == pytest.approx(np.std([1.0, 2.0, 3.0]))
+
+        stats_b = summary["oracle_stats"]["judge_b"]
+        assert stats_b["mean"] == pytest.approx(4.0)
+        assert stats_b["std"] == pytest.approx(0.0)
+
+    def test_pairwise_correlations_serialized_keys(self):
+        """Pairwise correlation keys should be 'oracle_a_vs_oracle_b' strings."""
+        scores = {
+            "alpha": [1.0, 2.0, 3.0, 4.0],
+            "beta": [1.0, 2.0, 3.0, 4.0],
+        }
+        summary = compute_agreement_summary(scores)
+
+        pearson_keys = list(summary["pairwise_correlations"]["pearson"].keys())
+        spearman_keys = list(summary["pairwise_correlations"]["spearman"].keys())
+
+        assert "alpha_vs_beta" in pearson_keys
+        assert "alpha_vs_beta" in spearman_keys
+
+    def test_mean_correlations_with_perfect_agreement(self):
+        scores = {
+            "a": [1.0, 2.0, 3.0, 4.0],
+            "b": [1.0, 2.0, 3.0, 4.0],
+        }
+        summary = compute_agreement_summary(scores)
+
+        assert summary["mean_pearson"] == pytest.approx(1.0)
+        assert summary["mean_spearman"] == pytest.approx(1.0)
+
+    def test_mean_correlations_none_when_insufficient_data(self):
+        """If all pairs have too few data points, mean correlations are None."""
+        scores = {
+            "a": [1.0, None],
+            "b": [None, 2.0],
+        }
+        summary = compute_agreement_summary(scores)
+
+        assert summary["mean_pearson"] is None
+        assert summary["mean_spearman"] is None
+
+    def test_handles_none_scores_in_oracle_stats(self):
+        scores = {
+            "judge_a": [1.0, None, 3.0],
+            "judge_b": [2.0, 2.0, 2.0],
+        }
+        summary = compute_agreement_summary(scores)
+
+        # judge_a: non-None values are [1.0, 3.0]
+        stats_a = summary["oracle_stats"]["judge_a"]
+        assert stats_a["n"] == 2
+        assert stats_a["mean"] == pytest.approx(2.0)
+
+    def test_two_judges_summary(self):
+        """Two judges minimum for a meaningful summary."""
+        scores = {
+            "x": [1.0, 2.0, 3.0],
+            "y": [1.0, 2.0, 3.0],
+        }
+        summary = compute_agreement_summary(scores)
+
+        assert summary["n_judges"] == 2
+        assert summary["krippendorff_alpha"] == pytest.approx(1.0)
+        assert summary["mean_pearson"] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# extract_scores_by_oracle
+# ---------------------------------------------------------------------------
+
+
+class TestExtractScoresByOracle:
+    def test_basic_extraction(self):
+        results = [
+            _make_sample_result({"oracle_a": 3.0, "oracle_b": 4.0}),
+            _make_sample_result({"oracle_a": 2.0, "oracle_b": 5.0}),
+        ]
+        scores = extract_scores_by_oracle(results)
+
+        assert set(scores.keys()) == {"oracle_a", "oracle_b"}
+        assert scores["oracle_a"] == [3.0, 4.0] or scores["oracle_a"] == [3.0, 2.0]
+        # Verify actual values
+        assert scores["oracle_a"] == [3.0, 2.0]
+        assert scores["oracle_b"] == [4.0, 5.0]
+
+    def test_missing_evaluation_produces_none(self):
+        """When an oracle is missing from a SampleResult, None is inserted."""
+        results = [
+            _make_sample_result({"oracle_a": 3.0, "oracle_b": 4.0}),
+            _make_sample_result({"oracle_a": 2.0}),  # oracle_b missing
+        ]
+        scores = extract_scores_by_oracle(results)
+
+        assert scores["oracle_a"] == [3.0, 2.0]
+        assert scores["oracle_b"] == [4.0, None]
+
+    def test_ragged_data_all_oracles_same_length(self):
+        """Even with ragged input, all oracle lists should be the same length."""
+        results = [
+            _make_sample_result({"a": 1.0}),
+            _make_sample_result({"b": 2.0}),
+            _make_sample_result({"a": 3.0, "b": 4.0}),
+        ]
+        scores = extract_scores_by_oracle(results)
+
+        assert len(scores["a"]) == 3
+        assert len(scores["b"]) == 3
+        assert scores["a"] == [1.0, None, 3.0]
+        assert scores["b"] == [None, 2.0, 4.0]
+
+    def test_empty_results_list(self):
+        scores = extract_scores_by_oracle([])
+        assert scores == {}
+
+    def test_single_oracle(self):
+        results = [
+            _make_sample_result({"only_judge": 3.5}),
+            _make_sample_result({"only_judge": 4.0}),
+        ]
+        scores = extract_scores_by_oracle(results)
+
+        assert list(scores.keys()) == ["only_judge"]
+        assert scores["only_judge"] == [3.5, 4.0]
+
+    def test_oracle_names_sorted(self):
+        results = [
+            _make_sample_result({"zebra": 1.0, "alpha": 2.0, "middle": 3.0}),
+        ]
+        scores = extract_scores_by_oracle(results)
+
+        assert list(scores.keys()) == ["alpha", "middle", "zebra"]
+
+    def test_three_oracles_one_missing_per_sample(self):
+        """Each sample is missing a different oracle."""
+        results = [
+            _make_sample_result({"a": 1.0, "b": 2.0}),  # c missing
+            _make_sample_result({"a": 3.0, "c": 4.0}),  # b missing
+            _make_sample_result({"b": 5.0, "c": 1.0}),  # a missing
+        ]
+        scores = extract_scores_by_oracle(results)
+
+        assert scores["a"] == [1.0, 3.0, None]
+        assert scores["b"] == [2.0, None, 5.0]
+        assert scores["c"] == [None, 4.0, 1.0]

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -407,3 +407,193 @@ class TestParameterEffects:
         assert abs(result["effects"][0]["effect_mean"]) >= abs(
             result["effects"][1]["effect_mean"]
         )
+
+
+# --- Multi-judge hierarchical model ---
+
+
+def make_multi_judge_results(n=20, oracle_scores=None, oracle_names=None, seed=42):
+    """Create SampleResults with multiple oracle evaluations."""
+    rng = np.random.default_rng(seed)
+    if oracle_names is None:
+        oracle_names = ["judge_a", "judge_b"]
+    if oracle_scores is None:
+        oracle_scores = {
+            name: [3.5 + rng.normal(0, 0.3) for _ in range(n)] for name in oracle_names
+        }
+
+    results = []
+    for i in range(n):
+        evaluations = {}
+        for name in oracle_names:
+            if i < len(oracle_scores[name]):
+                score = max(1.0, min(5.0, oracle_scores[name][i]))
+                evaluations[name] = EvaluationResult(score=score, explanation="ok")
+        results.append(
+            SampleResult(
+                sample_params={"param": i},
+                original_prompt="test prompt",
+                final_response="test response",
+                evaluations=evaluations,
+            )
+        )
+    return results
+
+
+@pytest.mark.slow
+class TestMultiJudgeQuality:
+    def test_returns_expected_keys_without_expected_score(self):
+        results = make_multi_judge_results(n=10)
+        analyzer = BayesianAnalyzer(
+            results,
+            analysis_config=BayesianAnalysisConfig(
+                mcmc_draws=100, mcmc_tune=100, mcmc_chains=1
+            ),
+        )
+        result = analyzer.estimate_multi_judge_quality(["judge_a", "judge_b"])
+
+        expected_keys = {
+            "true_quality_mean",
+            "true_quality_median",
+            "true_quality_std",
+            "hdi_lower",
+            "hdi_upper",
+            "hdi_prob",
+            "judges",
+            "bias_corrected_weighted_score",
+            "n_judges",
+            "n_total_evaluations",
+        }
+        assert set(result.keys()) == expected_keys
+        assert result["n_judges"] == 2
+        assert result["n_total_evaluations"] == 20
+        assert result["hdi_prob"] == 0.94
+
+        # Check per-judge keys
+        judge_keys = {
+            "bias_mean",
+            "bias_hdi",
+            "noise_mean",
+            "noise_hdi",
+            "n_evaluations",
+            "raw_score_mean",
+            "raw_score_std",
+            "consistency_weight",
+        }
+        for name in ["judge_a", "judge_b"]:
+            assert name in result["judges"]
+            assert set(result["judges"][name].keys()) == judge_keys
+
+    def test_returns_expected_keys_with_expected_score(self):
+        results = make_multi_judge_results(n=10)
+        analyzer = BayesianAnalyzer(
+            results,
+            analysis_config=BayesianAnalysisConfig(
+                mcmc_draws=100, mcmc_tune=100, mcmc_chains=1
+            ),
+        )
+        result = analyzer.estimate_multi_judge_quality(
+            ["judge_a", "judge_b"], expected_score=3.5
+        )
+
+        expected_keys = {
+            "expected_score",
+            "hdi_prob",
+            "judges",
+            "n_judges",
+            "n_total_evaluations",
+        }
+        assert set(result.keys()) == expected_keys
+        assert result["expected_score"] == 3.5
+        assert "true_quality_mean" not in result
+
+    def test_detects_bias(self):
+        """Judge with +1.0 offset should have positive bias."""
+        rng = np.random.default_rng(42)
+        n = 20
+        oracle_scores = {
+            "unbiased": [3.0 + rng.normal(0, 0.2) for _ in range(n)],
+            "biased": [4.0 + rng.normal(0, 0.2) for _ in range(n)],
+        }
+        results = make_multi_judge_results(
+            n=n,
+            oracle_scores=oracle_scores,
+            oracle_names=["unbiased", "biased"],
+        )
+        analyzer = BayesianAnalyzer(
+            results,
+            analysis_config=BayesianAnalysisConfig(
+                mcmc_draws=200, mcmc_tune=200, mcmc_chains=2
+            ),
+        )
+        result = analyzer.estimate_multi_judge_quality(["unbiased", "biased"])
+
+        # Biased judge should have higher bias than unbiased
+        assert (
+            result["judges"]["biased"]["bias_mean"]
+            > result["judges"]["unbiased"]["bias_mean"]
+        )
+
+    def test_noisy_judge_higher_noise(self):
+        """Noisy judge gets higher noise estimate."""
+        rng = np.random.default_rng(42)
+        n = 30
+        oracle_scores = {
+            "precise": [3.5 + rng.normal(0, 0.1) for _ in range(n)],
+            "noisy": [3.5 + rng.normal(0, 0.8) for _ in range(n)],
+        }
+        results = make_multi_judge_results(
+            n=n,
+            oracle_scores=oracle_scores,
+            oracle_names=["precise", "noisy"],
+        )
+        analyzer = BayesianAnalyzer(
+            results,
+            analysis_config=BayesianAnalysisConfig(
+                mcmc_draws=200, mcmc_tune=200, mcmc_chains=2
+            ),
+        )
+        result = analyzer.estimate_multi_judge_quality(["precise", "noisy"])
+
+        assert (
+            result["judges"]["noisy"]["noise_mean"]
+            > result["judges"]["precise"]["noise_mean"]
+        )
+
+    def test_consistency_weights_sum_to_one(self):
+        results = make_multi_judge_results(n=15)
+        analyzer = BayesianAnalyzer(
+            results,
+            analysis_config=BayesianAnalysisConfig(
+                mcmc_draws=100, mcmc_tune=100, mcmc_chains=1
+            ),
+        )
+        result = analyzer.estimate_multi_judge_quality(["judge_a", "judge_b"])
+
+        total = sum(info["consistency_weight"] for info in result["judges"].values())
+        assert abs(total - 1.0) < 1e-6
+
+    def test_handles_ragged_data(self):
+        """Different eval counts per judge."""
+        rng = np.random.default_rng(42)
+        # Judge A has 20 evals, Judge B has 15
+        oracle_scores = {
+            "judge_a": [3.5 + rng.normal(0, 0.3) for _ in range(20)],
+            "judge_b": [3.5 + rng.normal(0, 0.3) for _ in range(15)],
+        }
+        results = make_multi_judge_results(
+            n=20,
+            oracle_scores=oracle_scores,
+            oracle_names=["judge_a", "judge_b"],
+        )
+        analyzer = BayesianAnalyzer(
+            results,
+            analysis_config=BayesianAnalysisConfig(
+                mcmc_draws=100, mcmc_tune=100, mcmc_chains=1
+            ),
+        )
+        result = analyzer.estimate_multi_judge_quality(["judge_a", "judge_b"])
+
+        assert result["judges"]["judge_a"]["n_evaluations"] == 20
+        assert result["judges"]["judge_b"]["n_evaluations"] == 15
+        assert result["n_total_evaluations"] == 35

--- a/tests/test_calibration_report.py
+++ b/tests/test_calibration_report.py
@@ -26,18 +26,28 @@ def make_calibrate_config(**overrides):
     return CalibrateConfig(**defaults)
 
 
-def make_analysis_result():
-    return {
-        "population_mean": 4.0,
-        "population_median": 4.1,
-        "population_std": 0.3,
-        "hdi_lower": 3.5,
-        "hdi_upper": 4.5,
-        "hdi_prob": 0.94,
-        "oracle_noise_mean": 0.3,
-        "oracle_noise_hdi": (0.1, 0.5),
+def make_analysis_result(expected_score=None):
+    """Create mock judge calibration result (new structure)."""
+    result = {
+        "noise_mean": 0.3,
+        "noise_hdi": (0.1, 0.5),
         "n_samples": 10,
+        "hdi_prob": 0.94,
+        "raw_score_mean": 4.0,
+        "raw_score_std": 0.3,
     }
+    if expected_score is not None:
+        result["expected_score"] = expected_score
+        result["bias_mean"] = 4.0 - expected_score
+        result["bias_median"] = 4.0 - expected_score
+        result["bias_hdi"] = (
+            4.0 - expected_score - 0.2,
+            4.0 - expected_score + 0.2,
+        )
+    else:
+        result["estimated_quality_mean"] = 4.0
+        result["estimated_quality_hdi"] = (3.5, 4.5)
+    return result
 
 
 class TestCalibrationReportGenerator:
@@ -54,10 +64,10 @@ class TestCalibrationReportGenerator:
         assert output_path.exists()
 
         html = output_path.read_text()
-        assert "MetaReason Calibration Report" in html
+        assert "MetaReason" in html
+        assert "Calibration Report" in html
         assert "cal-test" in html
-        assert "Confidence Assessment" in html
-        assert "posteriorChart" in html
+        assert "Judge Assessment" in html
         assert "histogramChart" in html
         assert "noiseChart" in html
         assert "test-model" in html
@@ -65,16 +75,16 @@ class TestCalibrationReportGenerator:
     def test_with_expected_score(self, tmp_path):
         config = make_calibrate_config(expected_score=4.0)
         scores = [4.0, 3.5, 4.5, 4.0, 3.0, 5.0, 4.0, 4.5, 3.5, 4.0]
-        analysis = make_analysis_result()
+        analysis = make_analysis_result(expected_score=4.0)
 
         generator = CalibrationReportGenerator(config, scores, analysis)
         output_path = tmp_path / "report.html"
         generator.generate_html(output_path)
 
         html = output_path.read_text()
-        assert "Bias Analysis" in html
-        assert "Expected Score" in html
-        assert "Expected Within HDI" in html
+        assert "Judge Assessment" in html
+        assert "Accuracy (bias)" in html
+        assert "biasChart" in html
 
     def test_without_expected_score(self, tmp_path):
         config = make_calibrate_config()
@@ -86,21 +96,16 @@ class TestCalibrationReportGenerator:
         generator.generate_html(output_path)
 
         html = output_path.read_text()
-        assert "Bias Analysis" not in html
+        assert "biasChart" not in html  # No bias chart without expected_score
+        assert "Estimated Quality" in html
 
-    def test_chart_data_structure(self):
+    def test_chart_data_structure_without_expected(self):
         config = make_calibrate_config()
         scores = [4.0, 3.5, 4.5, 4.0, 3.0, 5.0, 4.0, 4.5, 3.5, 4.0]
         analysis = make_analysis_result()
 
         generator = CalibrationReportGenerator(config, scores, analysis)
         chart_data = generator._generate_chart_data()
-
-        # Posterior KDE data
-        assert "posterior_x" in chart_data
-        assert "posterior_y" in chart_data
-        assert len(chart_data["posterior_x"]) == 80
-        assert len(chart_data["posterior_y"]) == 80
 
         # Score histogram data
         assert "histogram_labels" in chart_data
@@ -115,19 +120,35 @@ class TestCalibrationReportGenerator:
         assert len(chart_data["noise_x"]) == 80
         assert len(chart_data["noise_y"]) == 80
 
-        # Annotation values
-        assert "hdi_lower" in chart_data
-        assert "hdi_upper" in chart_data
-        assert "population_mean" in chart_data
-        assert "population_median" in chart_data
+        # Noise annotation values
         assert "noise_mean" in chart_data
         assert "noise_hdi_lower" in chart_data
         assert "noise_hdi_upper" in chart_data
 
-    def test_collect_data(self):
+        # No bias data without expected_score
+        assert "bias_x" not in chart_data
+        assert chart_data["has_expected"] is False
+
+    def test_chart_data_structure_with_expected(self):
+        config = make_calibrate_config(expected_score=4.0)
+        scores = [4.0, 3.5, 4.5, 4.0, 3.0, 5.0, 4.0, 4.5, 3.5, 4.0]
+        analysis = make_analysis_result(expected_score=4.0)
+
+        generator = CalibrationReportGenerator(config, scores, analysis)
+        chart_data = generator._generate_chart_data()
+
+        # Bias KDE data should be present
+        assert "bias_x" in chart_data
+        assert "bias_y" in chart_data
+        assert "bias_mean" in chart_data
+        assert "bias_hdi_lower" in chart_data
+        assert "bias_hdi_upper" in chart_data
+        assert chart_data["has_expected"] is True
+
+    def test_collect_data_with_expected(self):
         config = make_calibrate_config(expected_score=4.0)
         scores = [4.0, 3.5, 4.5]
-        analysis = make_analysis_result()
+        analysis = make_analysis_result(expected_score=4.0)
 
         generator = CalibrationReportGenerator(config, scores, analysis)
         data = generator._collect_data()
@@ -139,8 +160,20 @@ class TestCalibrationReportGenerator:
         assert data["oracle_adapter"] == "ollama"
         assert data["has_expected"] is True
         assert data["expected_score"] == 4.0
-        assert data["bias"] == 0.0  # mean 4.0 - expected 4.0
-        assert data["within_hdi"] is True
+        assert data["verdict"] is not None
+        assert data["verdict_class"] is not None
+
+    def test_collect_data_without_expected(self):
+        config = make_calibrate_config()
+        scores = [4.0, 3.5, 4.5]
+        analysis = make_analysis_result()
+
+        generator = CalibrationReportGenerator(config, scores, analysis)
+        data = generator._collect_data()
+
+        assert data["has_expected"] is False
+        assert data["expected_score"] is None
+        assert data["verdict"] is None
 
     def test_creates_parent_directories(self, tmp_path):
         config = make_calibrate_config()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,6 +86,29 @@ def mock_population_quality():
     }
 
 
+def mock_judge_calibration(expected_score=None):
+    result = {
+        "noise_mean": 0.3,
+        "noise_hdi": (0.1, 0.5),
+        "n_samples": 5,
+        "hdi_prob": 0.94,
+        "raw_score_mean": 4.0,
+        "raw_score_std": 0.3,
+    }
+    if expected_score is not None:
+        result["expected_score"] = expected_score
+        result["bias_mean"] = 4.0 - expected_score
+        result["bias_median"] = 4.0 - expected_score
+        result["bias_hdi"] = (
+            4.0 - expected_score - 0.2,
+            4.0 - expected_score + 0.2,
+        )
+    else:
+        result["estimated_quality_mean"] = 4.0
+        result["estimated_quality_hdi"] = (3.5, 4.5)
+    return result
+
+
 @pytest.fixture
 def cli_runner():
     return CliRunner()
@@ -500,16 +523,13 @@ class TestCalibrateCommand:
         mock_judge_class.return_value = mock_judge
 
         mock_analyzer = MagicMock()
-        mock_analyzer.estimate_population_quality.return_value = (
-            mock_population_quality()
-        )
+        mock_analyzer.estimate_judge_calibration.return_value = mock_judge_calibration()
         mock_analyzer_class.return_value = mock_analyzer
 
         result = cli_runner.invoke(metareason, ["calibrate", str(spec_file)])
 
         assert result.exit_code == 0
         assert "Judge Calibration" in result.output
-        assert "confident" in result.output
         assert mock_judge.evaluate.call_count == 5
 
     @patch("metareason.cli.main.BayesianAnalyzer")
@@ -527,8 +547,8 @@ class TestCalibrateCommand:
         mock_judge_class.return_value = mock_judge
 
         mock_analyzer = MagicMock()
-        mock_analyzer.estimate_population_quality.return_value = (
-            mock_population_quality()
+        mock_analyzer.estimate_judge_calibration.return_value = mock_judge_calibration(
+            expected_score=4.0
         )
         mock_analyzer_class.return_value = mock_analyzer
 
@@ -536,7 +556,7 @@ class TestCalibrateCommand:
 
         assert result.exit_code == 0
         assert "Accuracy" in result.output
-        assert "Bias" in result.output
+        assert "Error" in result.output
 
     @patch("metareason.cli.main.BayesianAnalyzer")
     @patch("metareason.cli.main.LLMJudge")
@@ -554,9 +574,7 @@ class TestCalibrateCommand:
         mock_judge_class.return_value = mock_judge
 
         mock_analyzer = MagicMock()
-        mock_analyzer.estimate_population_quality.return_value = (
-            mock_population_quality()
-        )
+        mock_analyzer.estimate_judge_calibration.return_value = mock_judge_calibration()
         mock_analyzer_class.return_value = mock_analyzer
 
         result = cli_runner.invoke(
@@ -610,9 +628,7 @@ class TestCalibrateCommand:
         mock_judge_class.return_value = mock_judge
 
         mock_analyzer = MagicMock()
-        mock_analyzer.estimate_population_quality.return_value = (
-            mock_population_quality()
-        )
+        mock_analyzer.estimate_judge_calibration.return_value = mock_judge_calibration()
         mock_analyzer_class.return_value = mock_analyzer
 
         result = cli_runner.invoke(metareason, ["calibrate", str(spec_file)])
@@ -636,9 +652,7 @@ class TestCalibrateCommand:
         mock_judge_class.return_value = mock_judge
 
         mock_analyzer = MagicMock()
-        mock_analyzer.estimate_population_quality.return_value = (
-            mock_population_quality()
-        )
+        mock_analyzer.estimate_judge_calibration.return_value = mock_judge_calibration()
         mock_analyzer_class.return_value = mock_analyzer
 
         with patch(
@@ -672,9 +686,7 @@ class TestCalibrateCommand:
         mock_judge_class.return_value = mock_judge
 
         mock_analyzer = MagicMock()
-        mock_analyzer.estimate_population_quality.return_value = (
-            mock_population_quality()
-        )
+        mock_analyzer.estimate_judge_calibration.return_value = mock_judge_calibration()
         mock_analyzer_class.return_value = mock_analyzer
 
         with patch(
@@ -1076,3 +1088,302 @@ axes:
 
         mock_analyzer.estimate_parameter_effects.assert_not_called()
         assert "parameter_effects" not in analysis_results["coherence_judge"]
+
+
+# --- calibrate-multi command ---
+
+VALID_CALIBRATE_MULTI_YAML = """\
+spec_id: "multi-test"
+type: calibrate_multi
+prompt: "Test prompt"
+response: "Test response"
+repeats: 3
+oracles:
+  judge_a:
+    type: "llm_judge"
+    model: "model-a"
+    adapter:
+      name: "ollama"
+    rubric: "Rate 1-5"
+  judge_b:
+    type: "llm_judge"
+    model: "model-b"
+    adapter:
+      name: "ollama"
+    rubric: "Rate 1-5"
+analysis:
+  hdi_probability: 0.94
+  mcmc_draws: 200
+  mcmc_chains: 2
+  mcmc_tune: 100
+"""
+
+
+def mock_multi_judge_result():
+    return {
+        "true_quality_mean": 3.8,
+        "true_quality_median": 3.9,
+        "true_quality_std": 0.2,
+        "hdi_lower": 3.4,
+        "hdi_upper": 4.2,
+        "hdi_prob": 0.94,
+        "judges": {
+            "judge_a": {
+                "bias_mean": 0.1,
+                "bias_hdi": (-0.2, 0.4),
+                "noise_mean": 0.3,
+                "noise_hdi": (0.1, 0.5),
+                "consistency_weight": 0.6,
+                "n_evaluations": 3,
+                "raw_score_mean": 3.9,
+                "raw_score_std": 0.3,
+            },
+            "judge_b": {
+                "bias_mean": -0.1,
+                "bias_hdi": (-0.3, 0.1),
+                "noise_mean": 0.4,
+                "noise_hdi": (0.2, 0.6),
+                "consistency_weight": 0.4,
+                "n_evaluations": 3,
+                "raw_score_mean": 3.7,
+                "raw_score_std": 0.4,
+            },
+        },
+        "bias_corrected_weighted_score": 3.85,
+        "n_judges": 2,
+        "n_total_evaluations": 6,
+    }
+
+
+class TestCalibrateMultiCommand:
+    @patch("metareason.cli.main.BayesianAnalyzer")
+    @patch("metareason.cli.main.LLMJudge")
+    def test_calibrate_multi_basic(
+        self, mock_judge_class, mock_analyzer_class, cli_runner, tmp_path
+    ):
+        spec_file = tmp_path / "multi.yaml"
+        spec_file.write_text(VALID_CALIBRATE_MULTI_YAML)
+
+        mock_judge = MagicMock()
+        mock_judge.evaluate = AsyncMock(
+            return_value=EvaluationResult(score=4.0, explanation="good")
+        )
+        mock_judge_class.return_value = mock_judge
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.estimate_multi_judge_quality.return_value = (
+            mock_multi_judge_result()
+        )
+        mock_analyzer_class.return_value = mock_analyzer
+
+        result = cli_runner.invoke(metareason, ["calibrate-multi", str(spec_file)])
+
+        assert result.exit_code == 0
+        assert "Multi-Judge Calibration" in result.output
+
+    @patch("metareason.cli.main.BayesianAnalyzer")
+    @patch("metareason.cli.main.LLMJudge")
+    def test_calibrate_multi_with_output(
+        self, mock_judge_class, mock_analyzer_class, cli_runner, tmp_path
+    ):
+        spec_file = tmp_path / "multi.yaml"
+        spec_file.write_text(VALID_CALIBRATE_MULTI_YAML)
+        output_file = tmp_path / "multi_results.json"
+
+        mock_judge = MagicMock()
+        mock_judge.evaluate = AsyncMock(
+            return_value=EvaluationResult(score=4.0, explanation="good")
+        )
+        mock_judge_class.return_value = mock_judge
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.estimate_multi_judge_quality.return_value = (
+            mock_multi_judge_result()
+        )
+        mock_analyzer_class.return_value = mock_analyzer
+
+        result = cli_runner.invoke(
+            metareason,
+            ["calibrate-multi", str(spec_file), "-o", str(output_file)],
+        )
+
+        assert result.exit_code == 0
+        assert output_file.exists()
+
+        data = json.loads(output_file.read_text())
+        assert data["spec_id"] == "multi-test"
+        assert "multi_judge_analysis" in data
+
+    @patch("metareason.cli.main.BayesianAnalyzer")
+    @patch("metareason.cli.main.LLMJudge")
+    def test_calibrate_multi_with_report(
+        self, mock_judge_class, mock_analyzer_class, cli_runner, tmp_path
+    ):
+        spec_file = tmp_path / "multi.yaml"
+        spec_file.write_text(VALID_CALIBRATE_MULTI_YAML)
+
+        mock_judge = MagicMock()
+        mock_judge.evaluate = AsyncMock(
+            return_value=EvaluationResult(score=4.0, explanation="good")
+        )
+        mock_judge_class.return_value = mock_judge
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.estimate_multi_judge_quality.return_value = (
+            mock_multi_judge_result()
+        )
+        mock_analyzer_class.return_value = mock_analyzer
+
+        with patch("metareason.reporting.MultiJudgeReportGenerator") as mock_report_gen:
+            mock_generator = MagicMock()
+            mock_report_gen.return_value = mock_generator
+
+            result = cli_runner.invoke(
+                metareason,
+                ["calibrate-multi", str(spec_file), "--report"],
+            )
+
+            assert result.exit_code == 0
+            assert "HTML report saved" in result.output
+            mock_report_gen.assert_called_once()
+            mock_generator.generate_html.assert_called_once()
+
+    @patch("metareason.cli.main.LLMJudge")
+    def test_calibrate_multi_one_judge_fails_entirely(
+        self, mock_judge_class, cli_runner, tmp_path
+    ):
+        spec_file = tmp_path / "multi.yaml"
+        spec_file.write_text(VALID_CALIBRATE_MULTI_YAML)
+
+        # Both judges fail
+        mock_judge = MagicMock()
+        mock_judge.evaluate = AsyncMock(side_effect=RuntimeError("LLM unavailable"))
+        mock_judge_class.return_value = mock_judge
+
+        result = cli_runner.invoke(metareason, ["calibrate-multi", str(spec_file)])
+
+        assert result.exit_code == 0
+        assert "Fewer than 2 judges" in result.output
+
+    @patch("metareason.cli.main.BayesianAnalyzer")
+    @patch("metareason.cli.main.LLMJudge")
+    def test_calibrate_multi_partial_failures(
+        self, mock_judge_class, mock_analyzer_class, cli_runner, tmp_path
+    ):
+        spec_file = tmp_path / "multi.yaml"
+        spec_file.write_text(VALID_CALIBRATE_MULTI_YAML)
+
+        # Judge succeeds 2/3, fails 1/3
+        mock_judge = MagicMock()
+        mock_judge.evaluate = AsyncMock(
+            side_effect=[
+                EvaluationResult(score=4.0, explanation="good"),
+                RuntimeError("timeout"),
+                EvaluationResult(score=3.5, explanation="ok"),
+                EvaluationResult(score=4.0, explanation="good"),
+                RuntimeError("timeout"),
+                EvaluationResult(score=3.5, explanation="ok"),
+            ]
+        )
+        mock_judge_class.return_value = mock_judge
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.estimate_multi_judge_quality.return_value = (
+            mock_multi_judge_result()
+        )
+        mock_analyzer_class.return_value = mock_analyzer
+
+        result = cli_runner.invoke(metareason, ["calibrate-multi", str(spec_file)])
+
+        assert result.exit_code == 0
+        assert "Multi-Judge Calibration" in result.output
+
+
+# --- analyze --agreement flag ---
+
+
+MULTI_ORACLE_RESULTS_DATA = [
+    {
+        "sample_params": {"tone": "formal"},
+        "original_prompt": "test",
+        "final_response": "test response",
+        "evaluations": {
+            "judge_a": {"score": 4.0, "explanation": "good"},
+            "judge_b": {"score": 3.5, "explanation": "ok"},
+        },
+    },
+    {
+        "sample_params": {"tone": "casual"},
+        "original_prompt": "test",
+        "final_response": "test response",
+        "evaluations": {
+            "judge_a": {"score": 3.5, "explanation": "ok"},
+            "judge_b": {"score": 3.0, "explanation": "fair"},
+        },
+    },
+]
+
+MULTI_ORACLE_SPEC_YAML = """\
+spec_id: "test-multi"
+pipeline:
+  - template: "Hello {{ name }}"
+    adapter:
+      name: "ollama"
+    model: "test-model"
+    temperature: 0.7
+    top_p: 0.9
+    max_tokens: 100
+sampling:
+  method: "latin_hypercube"
+  optimization: "maximin"
+n_variants: 2
+oracles:
+  judge_a:
+    type: "llm_judge"
+    model: "model-a"
+    adapter:
+      name: "ollama"
+    rubric: "Rate 1-5"
+  judge_b:
+    type: "llm_judge"
+    model: "model-b"
+    adapter:
+      name: "ollama"
+    rubric: "Rate 1-5"
+"""
+
+
+class TestAnalyzeAgreementFlag:
+    @patch("metareason.cli.main.BayesianAnalyzer")
+    @patch("metareason.cli.main.load_spec")
+    def test_agreement_flag_shows_metrics(
+        self, mock_load_spec, mock_analyzer_class, cli_runner, tmp_path
+    ):
+        from metareason.pipeline.loader import load_spec as real_load_spec
+
+        spec_file = tmp_path / "spec.yaml"
+        spec_file.write_text(MULTI_ORACLE_SPEC_YAML)
+        results_file = tmp_path / "results.json"
+        results_file.write_text(json.dumps(MULTI_ORACLE_RESULTS_DATA))
+
+        mock_load_spec.return_value = real_load_spec(spec_file)
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.estimate_population_quality.return_value = (
+            mock_population_quality()
+        )
+        mock_analyzer_class.return_value = mock_analyzer
+
+        result = cli_runner.invoke(
+            metareason,
+            [
+                "analyze",
+                str(results_file),
+                "--spec",
+                str(spec_file),
+                "--agreement",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "alpha" in result.output.lower()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ from metareason.config.models import (
     AxisConfig,
     BayesianAnalysisConfig,
     CalibrateConfig,
+    CalibrateMultiConfig,
     OracleConfig,
     PipelineConfig,
     SamplingConfig,
@@ -242,6 +243,20 @@ class TestBayesianAnalysisConfig:
         with pytest.raises(ValidationError):
             BayesianAnalysisConfig(hdi_probability=0.0)
 
+    def test_prior_bias_sigma_default(self):
+        cfg = BayesianAnalysisConfig()
+        assert cfg.prior_bias_sigma == 1.0
+
+    def test_prior_bias_sigma_custom(self):
+        cfg = BayesianAnalysisConfig(prior_bias_sigma=2.0)
+        assert cfg.prior_bias_sigma == 2.0
+
+    def test_prior_bias_sigma_rejects_non_positive(self):
+        with pytest.raises(ValidationError):
+            BayesianAnalysisConfig(prior_bias_sigma=0.0)
+        with pytest.raises(ValidationError):
+            BayesianAnalysisConfig(prior_bias_sigma=-1.0)
+
 
 # --- SpecConfig ---
 
@@ -379,3 +394,96 @@ class TestCalibrateConfig:
         assert cfg.expected_score == 3.5
         assert cfg.repeats == 50
         assert cfg.analysis.mcmc_draws == 500
+
+
+# --- CalibrateMultiConfig ---
+
+
+class TestCalibrateMultiConfig:
+    def _make_two_oracles(self):
+        return {
+            "judge_a": make_oracle(),
+            "judge_b": make_oracle(model="gpt-4o"),
+        }
+
+    def test_valid_multi_config(self):
+        cfg = CalibrateMultiConfig(
+            spec_id="multi-1",
+            prompt="Test prompt",
+            response="Test response",
+            oracles=self._make_two_oracles(),
+        )
+        assert cfg.spec_id == "multi-1"
+        assert cfg.type == "calibrate_multi"
+        assert len(cfg.oracles) == 2
+
+    def test_multi_config_defaults(self):
+        cfg = CalibrateMultiConfig(
+            spec_id="multi",
+            prompt="p",
+            response="r",
+            oracles=self._make_two_oracles(),
+        )
+        assert cfg.repeats == 30
+        assert cfg.expected_score is None
+        assert cfg.analysis is None
+
+    def test_multi_config_rejects_single_oracle(self):
+        with pytest.raises(ValidationError):
+            CalibrateMultiConfig(
+                spec_id="multi",
+                prompt="p",
+                response="r",
+                oracles={"only_one": make_oracle()},
+            )
+
+    def test_multi_config_rejects_empty_oracles(self):
+        with pytest.raises(ValidationError):
+            CalibrateMultiConfig(
+                spec_id="multi",
+                prompt="p",
+                response="r",
+                oracles={},
+            )
+
+    def test_multi_config_three_oracles(self):
+        oracles = self._make_two_oracles()
+        oracles["judge_c"] = make_oracle(model="gemma3:27b")
+        cfg = CalibrateMultiConfig(
+            spec_id="multi-3",
+            prompt="p",
+            response="r",
+            oracles=oracles,
+        )
+        assert len(cfg.oracles) == 3
+
+    def test_multi_config_with_expected_score(self):
+        cfg = CalibrateMultiConfig(
+            spec_id="multi",
+            prompt="p",
+            response="r",
+            expected_score=4.0,
+            oracles=self._make_two_oracles(),
+        )
+        assert cfg.expected_score == 4.0
+
+    def test_multi_config_expected_score_bounds(self):
+        with pytest.raises(ValidationError):
+            CalibrateMultiConfig(
+                spec_id="multi",
+                prompt="p",
+                response="r",
+                expected_score=0.5,
+                oracles=self._make_two_oracles(),
+            )
+
+    def test_multi_config_with_analysis(self):
+        cfg = CalibrateMultiConfig(
+            spec_id="multi",
+            prompt="p",
+            response="r",
+            oracles=self._make_two_oracles(),
+            analysis=BayesianAnalysisConfig(mcmc_draws=500, prior_bias_sigma=2.0),
+        )
+        assert cfg.analysis.mcmc_draws == 500
+        assert cfg.analysis.prior_bias_sigma == 2.0

--- a/tests/test_multi_judge_report.py
+++ b/tests/test_multi_judge_report.py
@@ -1,0 +1,526 @@
+from metareason.config.models import (
+    AdapterConfig,
+    BayesianAnalysisConfig,
+    CalibrateMultiConfig,
+    OracleConfig,
+)
+from metareason.reporting.multi_judge_report import MultiJudgeReportGenerator
+
+
+def make_multi_config(**overrides):
+    defaults = dict(
+        spec_id="multi-cal-test",
+        type="calibrate_multi",
+        prompt="What is 2+2?",
+        response="The answer is 4.",
+        repeats=10,
+        oracles={
+            "judge_a": OracleConfig(
+                type="llm_judge",
+                model="model-a",
+                adapter=AdapterConfig(name="ollama"),
+                rubric="Rate 1-5",
+            ),
+            "judge_b": OracleConfig(
+                type="llm_judge",
+                model="model-b",
+                adapter=AdapterConfig(name="openai"),
+                rubric="Rate 1-5",
+            ),
+        },
+        analysis=BayesianAnalysisConfig(hdi_probability=0.94),
+    )
+    defaults.update(overrides)
+    return CalibrateMultiConfig(**defaults)
+
+
+def make_multi_judge_result(expected_score=None):
+    result = {
+        "hdi_prob": 0.94,
+        "n_judges": 2,
+        "n_total_evaluations": 20,
+        "judges": {
+            "judge_a": {
+                "bias_mean": 0.15,
+                "bias_hdi": (-0.05, 0.35),
+                "noise_mean": 0.40,
+                "noise_hdi": (0.20, 0.60),
+                "consistency_weight": 0.55,
+                "raw_score_mean": 4.20,
+                "raw_score_std": 0.45,
+                "n_evaluations": 10,
+            },
+            "judge_b": {
+                "bias_mean": -0.10,
+                "bias_hdi": (-0.30, 0.10),
+                "noise_mean": 0.50,
+                "noise_hdi": (0.25, 0.75),
+                "consistency_weight": 0.45,
+                "raw_score_mean": 3.90,
+                "raw_score_std": 0.55,
+                "n_evaluations": 10,
+            },
+        },
+    }
+    if expected_score is not None:
+        result["expected_score"] = expected_score
+    else:
+        result["true_quality_mean"] = 4.05
+        result["true_quality_median"] = 4.06
+        result["true_quality_std"] = 0.25
+        result["hdi_lower"] = 3.55
+        result["hdi_upper"] = 4.55
+        result["bias_corrected_weighted_score"] = 4.02
+    return result
+
+
+class TestMultiJudgeReportGeneratorInit:
+    def test_init_stores_attributes(self):
+        config = make_multi_config()
+        scores = {"judge_a": [4.0, 3.5], "judge_b": [3.0, 4.5]}
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+
+        assert gen.config is config
+        assert gen.scores_by_oracle is scores
+        assert gen.multi_judge is result
+
+
+class TestGenerateHtml:
+    def test_generates_html_file(self, tmp_path):
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.5, 4.5, 4.0, 3.0, 5.0, 4.0, 4.5, 3.5, 4.0],
+            "judge_b": [3.0, 3.5, 4.0, 3.5, 3.0, 4.5, 4.0, 3.5, 3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        output_path = tmp_path / "report.html"
+        returned = gen.generate_html(output_path)
+
+        assert returned == output_path
+        assert output_path.exists()
+
+        html = output_path.read_text()
+        assert "MetaReason Multi-Judge Report" in html
+        assert "multi-cal-test" in html
+
+    def test_html_contains_chart_canvases(self, tmp_path):
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.5, 4.5, 4.0, 3.0, 5.0, 4.0, 4.5, 3.5, 4.0],
+            "judge_b": [3.0, 3.5, 4.0, 3.5, 3.0, 4.5, 4.0, 3.5, 3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        output_path = tmp_path / "report.html"
+        gen.generate_html(output_path)
+
+        html = output_path.read_text()
+        assert "histogramChart" in html
+        assert "biasPosteriorChart" in html
+        assert "noisePosteriorChart" in html
+
+    def test_html_contains_judge_assessment(self, tmp_path):
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.5, 4.5, 4.0, 3.0, 5.0, 4.0, 4.5, 3.5, 4.0],
+            "judge_b": [3.0, 3.5, 4.0, 3.5, 3.0, 4.5, 4.0, 3.5, 3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        output_path = tmp_path / "report.html"
+        gen.generate_html(output_path)
+
+        html = output_path.read_text()
+        assert "Judge Comparison" in html
+        assert "Consistency Weight" in html
+
+    def test_creates_parent_directories(self, tmp_path):
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.5, 4.5],
+            "judge_b": [3.0, 3.5, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        output_path = tmp_path / "nested" / "dir" / "report.html"
+        gen.generate_html(output_path)
+
+        assert output_path.exists()
+
+
+class TestGenerateChartData:
+    def test_chart_data_has_expected_keys(self):
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.5, 4.5, 4.0, 3.0, 5.0, 4.0, 4.5, 3.5, 4.0],
+            "judge_b": [3.0, 3.5, 4.0, 3.5, 3.0, 4.5, 4.0, 3.5, 3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        chart_data = gen._generate_chart_data()
+
+        assert "judge_names" in chart_data
+        assert "judge_histograms" in chart_data
+        assert "bias_posteriors" in chart_data
+        assert "noise_posteriors" in chart_data
+        assert "histogram_labels" in chart_data
+        assert "has_expected" in chart_data
+
+    def test_judge_names_match_oracles(self):
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.5, 4.5, 4.0, 3.0, 5.0, 4.0, 4.5, 3.5, 4.0],
+            "judge_b": [3.0, 3.5, 4.0, 3.5, 3.0, 4.5, 4.0, 3.5, 3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        chart_data = gen._generate_chart_data()
+
+        assert set(chart_data["judge_names"]) == {"judge_a", "judge_b"}
+
+    def test_judge_histograms_per_judge(self):
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.5, 4.5, 4.0, 3.0, 5.0, 4.0, 4.5, 3.5, 4.0],
+            "judge_b": [3.0, 3.5, 4.0, 3.5, 3.0, 4.5, 4.0, 3.5, 3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        chart_data = gen._generate_chart_data()
+
+        assert "judge_a" in chart_data["judge_histograms"]
+        assert "judge_b" in chart_data["judge_histograms"]
+        # 5 bins for scores 1-5
+        assert len(chart_data["judge_histograms"]["judge_a"]) == 5
+        assert len(chart_data["judge_histograms"]["judge_b"]) == 5
+
+    def test_histogram_labels(self):
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.0],
+            "judge_b": [3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        chart_data = gen._generate_chart_data()
+
+        assert chart_data["histogram_labels"] == ["1", "2", "3", "4", "5"]
+
+    def test_bias_posteriors_per_judge(self):
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.0],
+            "judge_b": [3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        chart_data = gen._generate_chart_data()
+
+        assert "judge_a" in chart_data["bias_posteriors"]
+        assert "judge_b" in chart_data["bias_posteriors"]
+        for name in ("judge_a", "judge_b"):
+            bp = chart_data["bias_posteriors"][name]
+            assert "x" in bp
+            assert "y" in bp
+            assert "mean" in bp
+            assert "hdi_lower" in bp
+            assert "hdi_upper" in bp
+
+    def test_noise_posteriors_per_judge(self):
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.0],
+            "judge_b": [3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        chart_data = gen._generate_chart_data()
+
+        assert "judge_a" in chart_data["noise_posteriors"]
+        assert "judge_b" in chart_data["noise_posteriors"]
+        for name in ("judge_a", "judge_b"):
+            np_data = chart_data["noise_posteriors"][name]
+            assert "x" in np_data
+            assert "y" in np_data
+            assert "mean" in np_data
+
+
+class TestSelfContainedHtml:
+    def test_no_cdn_references(self, tmp_path):
+        """Multi-judge reports must work offline: no external CDN references."""
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.5, 4.5, 4.0, 3.0, 5.0, 4.0, 4.5, 3.5, 4.0],
+            "judge_b": [3.0, 3.5, 4.0, 3.5, 3.0, 4.5, 4.0, 3.5, 3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        output_path = tmp_path / "report.html"
+        gen.generate_html(output_path)
+
+        html = output_path.read_text()
+        assert (
+            "cdn.tailwindcss.com" not in html
+        ), "Tailwind CDN found; report is not self-contained"
+        assert (
+            "cdn.jsdelivr.net" not in html
+        ), "jsdelivr CDN found; report is not self-contained"
+        assert (
+            "fonts.googleapis.com" not in html
+        ), "Google Fonts CDN found; report is not self-contained"
+
+
+class TestWithExpectedScore:
+    def test_with_expected_score_shows_accuracy(self, tmp_path):
+        config = make_multi_config(expected_score=4.0)
+        scores = {
+            "judge_a": [4.0, 3.5, 4.5, 4.0, 3.0, 5.0, 4.0, 4.5, 3.5, 4.0],
+            "judge_b": [3.0, 3.5, 4.0, 3.5, 3.0, 4.5, 4.0, 3.5, 3.0, 4.0],
+        }
+        result = make_multi_judge_result(expected_score=4.0)
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        output_path = tmp_path / "report.html"
+        gen.generate_html(output_path)
+
+        html = output_path.read_text()
+        assert "Accuracy" in html
+
+    def test_collect_data_with_expected_score(self):
+        config = make_multi_config(expected_score=4.0)
+        scores = {
+            "judge_a": [4.0, 3.5],
+            "judge_b": [3.0, 4.0],
+        }
+        result = make_multi_judge_result(expected_score=4.0)
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        data = gen._collect_data()
+
+        assert data["has_expected"] is True
+        assert data["expected_score"] == 4.0
+        assert "judge_a" in data["judge_verdicts"]
+        assert "judge_b" in data["judge_verdicts"]
+
+
+class TestWithoutExpectedScore:
+    def test_without_expected_score_shows_estimated_quality(self, tmp_path):
+        config = make_multi_config()  # no expected_score
+        scores = {
+            "judge_a": [4.0, 3.5, 4.5, 4.0, 3.0, 5.0, 4.0, 4.5, 3.5, 4.0],
+            "judge_b": [3.0, 3.5, 4.0, 3.5, 3.0, 4.5, 4.0, 3.5, 3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        output_path = tmp_path / "report.html"
+        gen.generate_html(output_path)
+
+        html = output_path.read_text()
+        assert "Estimated Quality" in html
+
+    def test_collect_data_without_expected_score(self):
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.5],
+            "judge_b": [3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        data = gen._collect_data()
+
+        assert data["has_expected"] is False
+        assert data["expected_score"] is None
+
+
+class TestCollectData:
+    def test_collect_data_basic_fields(self):
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.0],
+            "judge_b": [3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        data = gen._collect_data()
+
+        assert data["spec_id"] == "multi-cal-test"
+        assert data["repeats"] == 10
+        assert data["n_judges"] == 2
+        assert data["hdi_pct"] == 94
+        assert "timestamp" in data
+        assert data["multi_judge"] is result
+        assert data["prompt"] == "What is 2+2?"
+        assert data["response"] == "The answer is 4."
+
+    def test_collect_data_recommendations_for_noisy_judge(self):
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.0],
+            "judge_b": [3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+        # Make judge_b noisy (noise > 1.0)
+        result["judges"]["judge_b"]["noise_mean"] = 1.5
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        data = gen._collect_data()
+
+        assert len(data["recommendations"]) == 1
+        assert "judge_b" in data["recommendations"][0]
+        assert "noise=1.50" in data["recommendations"][0]
+
+    def test_collect_data_no_recommendations_for_quiet_judges(self):
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.0],
+            "judge_b": [3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        data = gen._collect_data()
+
+        assert data["recommendations"] == []
+
+    def test_collect_data_uses_custom_hdi_probability(self):
+        config = make_multi_config(
+            analysis=BayesianAnalysisConfig(hdi_probability=0.89)
+        )
+        scores = {
+            "judge_a": [4.0, 3.0],
+            "judge_b": [3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        data = gen._collect_data()
+
+        assert data["hdi_pct"] == 89
+
+    def test_collect_data_default_hdi_without_analysis(self):
+        config = make_multi_config(analysis=None)
+        scores = {
+            "judge_a": [4.0, 3.0],
+            "judge_b": [3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        data = gen._collect_data()
+
+        assert data["hdi_pct"] == 94
+
+    def test_collect_data_judge_verdicts(self):
+        config = make_multi_config()
+        scores = {
+            "judge_a": [4.0, 3.0],
+            "judge_b": [3.0, 4.0],
+        }
+        result = make_multi_judge_result()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        data = gen._collect_data()
+
+        assert "judge_verdicts" in data
+        assert "judge_a" in data["judge_verdicts"]
+        assert "judge_b" in data["judge_verdicts"]
+        for v in data["judge_verdicts"].values():
+            assert "verdict" in v
+            assert "verdict_class" in v
+
+
+class TestThreeJudges:
+    """Verify the generator works with more than two judges."""
+
+    def _make_three_judge_fixtures(self):
+        config = make_multi_config(
+            oracles={
+                "judge_a": OracleConfig(
+                    type="llm_judge",
+                    model="model-a",
+                    adapter=AdapterConfig(name="ollama"),
+                    rubric="Rate 1-5",
+                ),
+                "judge_b": OracleConfig(
+                    type="llm_judge",
+                    model="model-b",
+                    adapter=AdapterConfig(name="openai"),
+                    rubric="Rate 1-5",
+                ),
+                "judge_c": OracleConfig(
+                    type="llm_judge",
+                    model="model-c",
+                    adapter=AdapterConfig(name="anthropic"),
+                    rubric="Rate 1-5",
+                ),
+            },
+        )
+        scores = {
+            "judge_a": [4.0, 3.5, 4.5, 4.0, 3.0, 5.0, 4.0, 4.5, 3.5, 4.0],
+            "judge_b": [3.0, 3.5, 4.0, 3.5, 3.0, 4.5, 4.0, 3.5, 3.0, 4.0],
+            "judge_c": [4.5, 4.0, 5.0, 4.5, 4.0, 5.0, 4.5, 5.0, 4.0, 4.5],
+        }
+        result = make_multi_judge_result()
+        result["n_judges"] = 3
+        result["judges"]["judge_c"] = {
+            "bias_mean": 0.50,
+            "bias_hdi": (0.25, 0.75),
+            "noise_mean": 0.30,
+            "noise_hdi": (0.15, 0.45),
+            "consistency_weight": 0.35,
+            "raw_score_mean": 4.50,
+            "raw_score_std": 0.40,
+            "n_evaluations": 10,
+        }
+        return config, scores, result
+
+    def test_three_judge_generates_html(self, tmp_path):
+        config, scores, result = self._make_three_judge_fixtures()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        output_path = tmp_path / "report.html"
+        gen.generate_html(output_path)
+
+        assert output_path.exists()
+        html = output_path.read_text()
+        assert "judge_a" in html
+        assert "judge_b" in html
+        assert "judge_c" in html
+
+    def test_three_judge_histograms(self):
+        config, scores, result = self._make_three_judge_fixtures()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        chart_data = gen._generate_chart_data()
+
+        assert len(chart_data["judge_names"]) == 3
+        assert "judge_c" in chart_data["judge_histograms"]
+        assert len(chart_data["judge_histograms"]["judge_c"]) == 5
+
+    def test_three_judge_posteriors(self):
+        config, scores, result = self._make_three_judge_fixtures()
+
+        gen = MultiJudgeReportGenerator(config, scores, result)
+        chart_data = gen._generate_chart_data()
+
+        assert len(chart_data["bias_posteriors"]) == 3
+        assert len(chart_data["noise_posteriors"]) == 3
+        assert "judge_c" in chart_data["bias_posteriors"]
+        assert "judge_c" in chart_data["noise_posteriors"]


### PR DESCRIPTION
…ality

Calibration evaluates judges, not responses. The Bayesian models, reports, and CLI output now target judge accuracy (bias) and consistency (noise) rather than estimating "true quality" of the response.

Single-judge: new estimate_judge_calibration() method anchors to expected_score when provided, estimating bias + noise directly.

Multi-judge: estimate_multi_judge_quality() accepts expected_score, drops true_quality parameter when the answer is known, and renames reliability_weight to consistency_weight.

Reports lead with per-judge assessment cards and plain-English verdicts. All labels use plain terms with technical terms in parentheses (e.g., "Accuracy (bias)", "Consistency (noise)"). Every data point has a help button (?) with an explanatory overlay.

Removed from calibration: agreement metrics (belong in metareason run), correlation heatmap, redundant bias bar chart. Added: per-judge bias and noise posterior KDE charts.

Tightened verdict thresholds from 0.3/0.5 to 0.2/0.2 — a judge that wanders ±0.46 on a 1-5 scale is not "well-calibrated."